### PR TITLE
Add more applicant data scenarios

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -44,13 +44,153 @@ const qualificationData = require('./qualificationData.json')
 
 // Setting the default layout settings
 var settings = {
-  enableErrors: "false"  
+  enableErrors: "false"
 }
 
-// This is all the data needed to populate a completed application
-var completedApplicationData = {
+// This is all the data needed to populate a VTQ completed application
+var completedApplicationDataVTQ = {
+
   // Personal details
   "fullName": "Lalita Vikram",
+  "email": "lalita@email.com",
+  "telephone": "07552068159",
+  "whereDoYouLive": "In the UK",
+  "addressLine1": "43 Watson Place",
+  "townOrCity": "Coventry",
+  "postCode": "CV1 1DE",
+  "personalDetailsCompleted": "complete",
+
+  // Education details
+  "anyQualifications": "Yes",
+  "schoolName": "British Occupational Hygiene Society",
+  "awordingOrganisation": "British Occupational Hygiene Society",
+  "qualName": "Certificate of Compentence in Asbestos",
+  "grade": "Pass",
+  "yearQualAwarded": "1995",
+  "qualUploadAvailable": "No",
+  "noQualReasonHtml": "I have lost it temporarily but I have an email from the Awarding Organisation confirming I have the qualification while I am awaiting my replacement certificate",
+  "qualificationUpload": "Not provided",
+  "educationCompleted": "complete",
+
+  // Work history
+  "employerName": "DAC",
+  "jobTitle": "Director",
+  "roleEnded": "No",
+  "workHistoryCompleted": "complete",
+  
+  // Professional memberships
+  "anyMemberships": "Yes",
+  "membershipOrganisationName": "BOHS",
+  "membershipType": "Member",
+  "membershipYearJoined": "2000",
+  "professionalMembershipsCompleted": "complete",
+    
+  // References
+  "referenceName": "Paul Hograft",
+  "referenceEmail": "PH@email.com",
+  "referenceTelephone": "Not provided",
+  "referenceOrganisation": "Engineering2 Limited (Chosen a colleague from an AO or someone from a professional membership)",
+  "referencesCompleted": "complete",
+  
+  // Types of expertise
+  
+  // Assessment
+  "anyAssessmentExpertise": "Yes",
+  "assessmentExpertiseType": [
+    "Checking and verifying the marking of others (as a moderator, or as an internal or external verifier)", 
+    "Designing and/or setting assessments",
+    "Designing or writing question papers or assessment tasks",
+    "Designing the assessment approach for a qualification",
+    "Determining key grade boundaries for examinations or assessments",
+    "Evaluating the effectiveness of specific assessment design and approaches",
+    "Leading a team of markers, examiners or assessors",
+    "Marking assessments",
+    "Reviewing or overseeing qualification standards",
+    "Reviewing the performance of assessments (individual questions, assessment tasks, mark schemes)",
+    "Reviewing the validity and reliability of the qualification, as part of the qualification lifecycle",
+    "Setting standards for qualification outcomes",
+    "Specification review Specification design",
+  ],
+  "assessmentExpertiseDetails": "I'd enter the qualifications I've been involved in the work designing the assessments, reviewing assessments and standardising the assessments. I'd put how long I had worked with the qualification if I had been involved from the start or entered within part of it. I'd detail my involvement and what we did in terms of designing the assessments. I'd detail the process of reviewing the qualifications and assessments and then detail the work on standardising.",
+  "assessmentExpertiseCompleted": "complete",
+
+  // Industry
+  "anyIndustryExpertise": "Yes",
+  "industryExpertiseDetails": "I'd be entering when I used to work as an Asbestos surveyor, my background, and when I trained and was a practicing surveyor. I would list the years that I had done this work, and who the work was for and I would detail activities, to show my experience and industry knowledge.",
+  "industryExpertiseCompleted": "complete",
+  
+  // Teaching
+  "anyTeachingExpertise": "Yes",
+  "currentlyInTeachingRole": "Yes",
+  "teachingExpertiseType": [
+    "Developing classroom materials",
+    "Developing teacher training materials",
+    "Training other teachers/ lecturers",
+    "Employer / Industry asbestos training Train asbestos training providers Commercial training provider Training other trainers",
+
+  ],
+  "teachingExpertiseDetails": "I would include here a specific summary of my teaching and training experience. I would link my work history and my roles and responsibilities and work done to these specific areas as you have directed. It is clear now, that where there isn't a space in 'Work history' to tell you about it what I've done. I can see now these sections and how you want my work history by experience in assessment, industry, and teacher training. (Note: It may have given me comfort to know that I would have the opportunity to tell you this information before now).",
+  "teachingExpertiseCompleted": "complete",
+
+  // Areas that you can advise on 
+  // Subject
+  "selectedSubject": "Asbestos Analyst and Surveyor (End-Point Assessment - Level 3)",
+  "resultName": "Asbestos Analyst and Surveyor",
+  "resultQualType": "End-Point Assessment",
+  "resultLevel": "Level 3",
+  "referrer": "subjectSearch",
+  "hasMultipleExpertiseTypes": "True",
+  "expertiseType": [
+    "Assessment", 
+    "Industry or occupational", 
+    "Teaching, lecturing or training"
+  ],
+  // Sector
+  "selectedIndustry": "Building and construction",
+  "selectedQualificationSector": [
+    "End-Point Assessment", 
+    "Technical Qualification", 
+    "Vocationally-Related Qualification"
+  ],
+  "selectedLevelSector": ["Level 4"],
+  "adviseAreasCompleted": "complete",
+  
+  // Conflict of interest
+  "conflictOfInterest": "Yes",
+  "conflictOrganisation": "RS Public Health",
+  "conflictType": "I work for an Awarding Organisation as an external consultant or advisor",
+  "conflictDetails": "I work for an awarding organisation, but I am not employed. I am contracted externally. I am training, assessor, and examiner for the qualification they award. I would put the detail of the years I was an assessor for them and if I am no longer doing any work for them I'd make it clear I haven't and don't do any work for them etc.",
+  "conflictStartDate": "June 2005",
+  "currentConflict": "No",
+  "conflictEndDate": "March 2015",
+  "conflictOfInterestCompleted": "complete",
+  
+  // Self declaration
+  "judgements": "No",
+  // "judgementsDetails": "Test",
+  "bankrupt": "No",
+  // "bankruptDetails": "Test",
+  "misconduct": "No",
+  // "misconductDetails": "Test",
+  "breach": "No",
+  // "breachDetails": "I didn't pay my tax for a REALLY long time.",
+  "declarationCompleted": "complete",
+  
+  // Your right to work status
+  "rightToWork": "Yes",
+  "rightToWorkStatus": "UK citizenship",
+  "rightToWorkCompleted": "complete",
+
+  // Provide proof of identification
+  "idUpload": "passport.pdf",
+  "verifyIdentityCompleted": "complete"
+}
+
+// This is all the data needed to populate a VTQ completed application
+var completedApplicationDataGQ = {
+
+  // Personal details
+  "fullName": "GQ Lalita Vikram",
   "email": "lalita@email.com",
   "telephone": "07552068159",
   "whereDoYouLive": "In the UK",
@@ -211,7 +351,8 @@ module.exports = {
   qualificationData,
   subjectSearch2Data,
 
-  completedApplicationData,
+  completedApplicationDataGQ,
+  completedApplicationDataVTQ,
   
   settings: settings,
 

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -186,7 +186,7 @@ var completedApplicationDataVTQ = {
   "verifyIdentityCompleted": "complete"
 }
 
-// This is all the data needed to populate a VTQ completed application
+// This is all the data needed to populate a GQ completed application
 var completedApplicationDataGQ = {
 
   // Personal details
@@ -327,6 +327,7 @@ var completedApplicationDataGQ = {
 
 module.exports = {
 
+  // This section pulls in various data sources
   routeData,
   agricultureData,
   allOccupationData,
@@ -357,7 +358,7 @@ module.exports = {
   settings: settings,
 
   // Setting the sections that aren't able to be started yet
-  // The section is enabled with a hidden inputs in the dependant sections
+  // The section is enabled with hidden inputs in the dependant section
   "adviseAreasCompleted": "canNotStartYet"
 
 }

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -135,8 +135,8 @@ var completedApplicationData = {
   // Subject
   "selectedSubject": "Asbestos Analyst and Surveyor (End-Point Assessment - Level 3)",
   "resultName": "Asbestos Analyst and Surveyor",
-  "selectedQualification": ["End-Point Assessment"],
-  "selectedLevel": ["Level 3"],
+  "resultQualType": "End-Point Assessment",
+  "resultLevel": "Level 3",
   "referrer": "subjectSearch",
   "hasMultipleExpertiseTypes": "True",
   "expertiseType": [
@@ -214,7 +214,6 @@ module.exports = {
   completedApplicationData,
   
   settings: settings,
-  // personalDetails: personalDetails,
 
   // Setting the sections that aren't able to be started yet
   // The section is enabled with a hidden inputs in the dependant sections

--- a/app/routes.js
+++ b/app/routes.js
@@ -477,28 +477,48 @@ router.post('/equality-question-answer', function (req, res) {
 })
 
 // View the application in different states
+// VTQ Application
 
 // Sets up the tasklist with a completed application when you visit a link
-router.all( '/populate-application', function (req, res) {
-  req.session.data = Object.assign(req.session.data.completedApplicationData)  
+router.all( '/populate-application-vtq', function (req, res) {
+  req.session.data = Object.assign(req.session.data.completedApplicationDataVTQ)  
   res.redirect('/application');
-
 })
 
 // Sets up the tasklist with a completed applicationwhen you visit a link
-router.all( '/application-submitted-in-review', function (req, res) {
-  req.session.data = Object.assign(req.session.data.completedApplicationData)
+router.all( '/application-submitted-vtq-in-review', function (req, res) {
+  req.session.data = Object.assign(req.session.data.completedApplicationDataVTQ)
   
-  res.redirect('/dashboard?applicationStatus=inReview');
-
+  res.redirect('/dashboard?applicationStatus=In review');
 })
 
 // Sets up the tasklist with a completed application when you visit a link
-router.all( '/application-submitted-accepted', function (req, res) {
-  req.session.data = Object.assign(req.session.data.completedApplicationData)
+router.all( '/application-submitted-vtq-accepted', function (req, res) {
+  req.session.data = Object.assign(req.session.data.completedApplicationDataVTQ)
   
-  res.redirect('/dashboard?applicationStatus=applicationAccepted');
+  res.redirect('/dashboard?applicationStatus=Application accepted');
+})
 
+// GQ Application
+
+// Sets up the tasklist with a completed application when you visit a link
+router.all( '/populate-application-gq', function (req, res) {
+  req.session.data = Object.assign(req.session.data.completedApplicationDataGQ)  
+  res.redirect('/application');
+})
+
+// Sets up the tasklist with a completed applicationwhen you visit a link
+router.all( '/application-submitted-gq-in-review', function (req, res) {
+  req.session.data = Object.assign(req.session.data.completedApplicationDataGQ)
+  
+  res.redirect('/dashboard?applicationStatus=In review');
+})
+
+// Sets up the tasklist with a completed application when you visit a link
+router.all( '/application-submitted-gq-accepted', function (req, res) {
+  req.session.data = Object.assign(req.session.data.completedApplicationDataGQ)
+  
+  res.redirect('/dashboard?applicationStatus=Application accepted');
 })
 
 // ------ Register your interest  ----- //

--- a/app/routes.js
+++ b/app/routes.js
@@ -377,7 +377,9 @@ router.post('/application/search/subject-search-answer', function (req, res) {
   }
 })
 
-// Did you want to add another qualification?
+// What type of expertise do you have for this industry or sector?
+// Joe helped me write this one too
+
 router.post('/select-level-answer', function (req, res) {
 
   const assessmentExpertise = req.session.data.anyAssessmentExpertise
@@ -400,7 +402,7 @@ router.post('/select-level-answer', function (req, res) {
     hasMultipleExpertiseTypes = false
   }
     
-  // at least 2 expertise types have been selected os we need them to tell us more   
+  // at least 2 expertise types have been selected so we need them to tell us more   
   if (hasMultipleExpertiseTypes === true) {
     res.redirect('/application/search/select-expertise-type')
   // must have selected only one type of expertise  
@@ -486,6 +488,7 @@ router.all( '/populate-application-vtq', function (req, res) {
 })
 
 // Sets up the tasklist with a completed applicationwhen you visit a link
+// The '?applicationStatus=...' is tells the prototype which status the aplication is in
 router.all( '/application-submitted-vtq-in-review', function (req, res) {
   req.session.data = Object.assign(req.session.data.completedApplicationDataVTQ)
   
@@ -493,6 +496,7 @@ router.all( '/application-submitted-vtq-in-review', function (req, res) {
 })
 
 // Sets up the tasklist with a completed application when you visit a link
+// The '?applicationStatus=...' is tells the prototype which status the aplication is in
 router.all( '/application-submitted-vtq-accepted', function (req, res) {
   req.session.data = Object.assign(req.session.data.completedApplicationDataVTQ)
   
@@ -508,6 +512,7 @@ router.all( '/populate-application-gq', function (req, res) {
 })
 
 // Sets up the tasklist with a completed applicationwhen you visit a link
+// The '?applicationStatus=...' is tells the prototype which status the aplication is in
 router.all( '/application-submitted-gq-in-review', function (req, res) {
   req.session.data = Object.assign(req.session.data.completedApplicationDataGQ)
   
@@ -515,6 +520,7 @@ router.all( '/application-submitted-gq-in-review', function (req, res) {
 })
 
 // Sets up the tasklist with a completed application when you visit a link
+// The '?applicationStatus=...' is tells the prototype which status the aplication is in
 router.all( '/application-submitted-gq-accepted', function (req, res) {
   req.session.data = Object.assign(req.session.data.completedApplicationDataGQ)
   

--- a/app/views/_includes/summary-cards/application-status.html
+++ b/app/views/_includes/summary-cards/application-status.html
@@ -3,12 +3,12 @@
   {% endset %}
 
   {% set applicationStatusHtml %}
-    {% if data.applicationStatus == "inReview" %}
+    {% if data.applicationStatus == "In review" %}
       {{govukTag({
         text: "Review pending",
         classes: "govuk-tag--yellow"
       })}}
-    {% elseif data.applicationStatus == "applicationAccepted" %}
+    {% elseif data.applicationStatus == "Application accepted" %}
       {{govukTag({
         text: "Application accepted",
         classes: "govuk-tag--green"

--- a/app/views/admin.html
+++ b/app/views/admin.html
@@ -85,31 +85,6 @@
     ]
   } | decorateAttributes(data, "data.adviseAreasCompleted")) }}
 
-  {# <hr class="govuk-section-break govuk-section-break--visible">
-
-  <h2 class="govuk-heading-l">View an application in different statuses<h2>
-
-  {{ govukRadios({
-    fieldset: {
-      legend: {
-        text: "Application status",
-        classes: "govuk-fieldset__legend--m"
-      }
-    },
-    items: [
-      {
-        text: "In review"      
-      },
-      {
-        text: "Changes requested"
-      },
-      {
-        text: "Application accepted"
-      }
-    ]
-  } | decorateAttributes(data, "data.settings.applicationStatus")) }}   #}
-  
-
   {{ govukButton({
     text: "Update settings"
   }) }}

--- a/app/views/admin.html
+++ b/app/views/admin.html
@@ -2,7 +2,7 @@
 {% extends "_templates/form-template.html" %}
 
 {% set pageHeading = "Admin settings" %}
-{% set formAction = "/application" %}
+{% set formAction = "/index" %}
 
 {% block formContent %}
 
@@ -87,16 +87,27 @@
 
   {# <hr class="govuk-section-break govuk-section-break--visible">
 
-  <h2 class="govuk-heading-l">View the application in various states<h2>
-  <h3 class="govuk-heading-s">Before submit<h3>
+  <h2 class="govuk-heading-l">View an application in different statuses<h2>
 
-  <p class="govuk-body"><a href="/populate-application" class="govuk">View a completed application</a></p>
-
-  <h3 class="govuk-heading-s">After submit<h3>
-
-  <p class="govuk-body"><a href="/application-submitted-in-review" class="govuk">View a submitted application: "In review"</a></p>
-  <p class="govuk-body"><a href="/application-submitted-accepted" class="govuk">View a submitted application: "Application accepted"</a></p>
-  <p class="govuk-body"><a href="#" class="govuk">View a submitted application: "More information required"</a></p> #}
+  {{ govukRadios({
+    fieldset: {
+      legend: {
+        text: "Application status",
+        classes: "govuk-fieldset__legend--m"
+      }
+    },
+    items: [
+      {
+        text: "In review"      
+      },
+      {
+        text: "Changes requested"
+      },
+      {
+        text: "Application accepted"
+      }
+    ]
+  } | decorateAttributes(data, "data.settings.applicationStatus")) }}   #}
   
 
   {{ govukButton({

--- a/app/views/application/search/subject-search.html
+++ b/app/views/application/search/subject-search.html
@@ -15,6 +15,11 @@
     }) %}
   {% endfor %}
 
+  {# Note for future designers #}
+  {# Joe Ingledew helped me build this feature and I apologise in advance for it being held together with sticky tape and bubble gum! #}
+
+  {# This section is populated by data found here: /data/subjectSearchData2.json #}
+
   {% set sub = []  %}
   
   {% for s in data.subjectSearch2Data  %}
@@ -41,11 +46,11 @@
 
     <script type="text/javascript">
 
-    let rawResults = [
-      {% for s in data.subjectSearch2Data %}
-        { "name": "{{s.name}}", "qualType": "{{s.qualType}}", "level": "{{s.level}}" },
-      {% endfor %}
-    ]
+      let rawResults = [
+        {% for s in data.subjectSearch2Data %}
+          { "name": "{{s.name}}", "qualType": "{{s.qualType}}", "level": "{{s.level}}" },
+        {% endfor %}
+      ]
 
       const results = rawResults.map((x, ix) => ({ id: ix, ...x }))
 

--- a/app/views/dashboard.html
+++ b/app/views/dashboard.html
@@ -4,11 +4,11 @@
 {% set backLink = "false" %}
 {% set primaryNavActive = "Dashboard" %}
 
-{% if data.applicationStatus == "inReview" %}
+{% if data.applicationStatus == "In review" %}
   {% set pageHeading = "My application" %}
 {% endif %}
 
-{% if data.applicationStatus == "applicationAccepted" %}
+{% if data.applicationStatus == "Application accepted" %}
   {% set pageHeading = "My account" %}
   {% set pageType = "Dashboard" %}
 {% endif %}
@@ -17,7 +17,7 @@
 
   <div class="govuk-grid-row">
     {# Show the success banner if the application is in review #}
-    {% if data.applicationStatus == "inReview" %}
+    {% if data.applicationStatus == "In review" %}
       <div class="govuk-grid-column-full">
         {% set html %}
           <h3 class="govuk-notification-banner__heading">
@@ -34,11 +34,11 @@
     
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-      {% if data.applicationStatus == "inReview" %}
+      {% if data.applicationStatus == "In review" %}
         <p class="govuk-body">Your application has been submitted. You will get an email once it has been reviewed.</p>
         <p class="govuk-body">You can make changes to your application until it is assigned to an evaluator.</p>
       {% endif %}
-      {% if data.applicationStatus == "applicationAccepted" %}
+      {% if data.applicationStatus == "Application accepted" %}
         <p class="govuk-body">Your application has been acepted.</p>
         <p class="govuk-body">You can now bid for work and do other stuff.</p>
       {% endif %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -34,12 +34,15 @@
       <h2 class="govuk-heading-m">View the application in various states<h2>
       <h3 class="govuk-heading-s">Before submit<h3>
 
-      <p class="govuk-body"><a href="/populate-application" class="govuk">View a completed application</a></p>
+      <p class="govuk-body"><a href="/populate-application-gq" class="govuk">GQ - View a completed application</a></p>
+      <p class="govuk-body"><a href="/populate-application-vtq" class="govuk">VTQ - View a completed application</a></p>
 
       <h3 class="govuk-heading-s">Dashboard - after submit<h3>
 
-      <p class="govuk-body"><a href="/application-submitted-in-review" class="govuk">View a submitted application: "In review"</a></p>
-      <p class="govuk-body"><a href="/application-submitted-accepted" class="govuk">View a submitted application: "Application accepted"</a></p>
+      <p class="govuk-body"><a href="/application-submitted-gq-in-review" class="govuk">GQ - View a submitted application (In review)</a></p>
+      <p class="govuk-body"><a href="/application-submitted-vtq-in-review" class="govuk">VTQ - View a submitted application (In review)</a></p>
+      <p class="govuk-body"><a href="/application-submitted-gq-accepted" class="govuk">GQ - View a submitted application (Application accepted)</a></p>
+      <p class="govuk-body"><a href="/application-submitted-vtq-accepted" class="govuk">VTQ - View a submitted application (Application accepted)</a></p>
       
       {# <h2 class="govuk-heading-m">Demos</h2>
       <a href="/application/expertise/select-occupation-demo" class="govuk-body">Select an occupation (Option search/select demo)</a> #}


### PR DESCRIPTION
This PR sets up another set of data (placeholder data for now) so we can toggle between completed applications for two types of user:

1. VTQ leaning experts
2. GQ leaning experts

You can switch between these views from the index.

**Next steps**
Clair to add GQ data


![Screenshot 2022-11-15 at 09 04 04](https://user-images.githubusercontent.com/1108991/201879178-e08abbba-9c8f-4dd8-960f-5e7ce5aea6e9.png)
