### PR TITLE
Add read only email input and details component.

### DIFF
--- a/app/views/application/personal-details/index.html
+++ b/app/views/application/personal-details/index.html
@@ -21,16 +21,7 @@
       },
       type: "text"
   } | decorateAttributes(data, "data.fullName")) }}
-
-  {{ govukInput({
-    label: {
-      text: "Email address",
-      classes: "govuk-label--s"
-    },
-    type: "email",
-    autocomplete: "email",
-    spellcheck: false
-  } | decorateAttributes(data, "data.email")) }}
+  
 
   {{ govukInput({
     label: {
@@ -44,7 +35,31 @@
     autocomplete: "tel",
     classes: "govuk-!-width-two-thirds"
  } | decorateAttributes(data, "data.telephone")) }}
+  
+  {{ govukInput({
+    label: {
+      text: "Email address",
+      classes: "govuk-label--s"
+    },
+    attributes: {
+      readonly: "readonly"
+    },
+    type: "email",
+    autocomplete: "email",
+    spellcheck: false,
+    value: "email@email.com"
+  } | decorateAttributes(data, "data.email")) }}
 
+  {% set detailsHtml %}
+    <p class="govuk-body">This is the email address you used to create your GOV.UK account.<br>
+      <a href="#" class="govul-link">Update your email address on GOV.UK Sign in</a>
+    </p>
+  {% endset %}
+
+  {{ govukDetails({
+    summaryText: "How do I change my email address?",
+    html: detailsHtml
+  }) }}
 
   <div class="govuk-button-group">
     {{ govukButton({


### PR DESCRIPTION
We currently ask the applicant for their email on the Personal information screen BUT we already now their email address as they need one to create a [GOV.UK](http://gov.uk/) Sign in account.

In the first instance and to keep things simple, I'm suggesting we not let applicants provide a second email address. It will mean we have to manage two email fields in the back end and also creates opportunity for a confusing experience for the applicant. Why email does what eh?

Updated screen:

![Screenshot 2022-11-18 at 11 46 06](https://user-images.githubusercontent.com/1108991/202738621-a8e63113-deb7-4223-994c-0210d0dbdd7a.png)

