### PR TITLE
Updating route to subject expertise details when only one type of expertise selected

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -373,7 +373,7 @@ router.post('/application/search/subject-search-answer', function (req, res) {
     res.redirect('/application/search/select-expertise-type?referrer=subjectSearch')
   // the user has selected less than 2 areas of expertise so we skip that screen in the flow and go straight to the review page  
   } else {
-    res.redirect('/application/search/review')
+    res.redirect('/application/search/add-details')
   }
 })
 
@@ -407,7 +407,7 @@ router.post('/select-level-answer', function (req, res) {
     res.redirect('/application/search/select-expertise-type')
   // must have selected only one type of expertise  
   } else {
-    res.redirect('/application/search/review') 
+    res.redirect('/application/search/add-details') 
   }
 
 })

--- a/app/views/application/search/add-details.html
+++ b/app/views/application/search/add-details.html
@@ -53,16 +53,6 @@
   {% endif %}
 {% endset %}
 
-{% set pageDescription2 %}
-  {# If they are coming through the Industry/Sector flow #}
-  {% if data.referrer == "sectorSearch" %}
-    If you have selected a qualification type and level, detail your expertise in your sector at the qualification type and level(s). 
-  {# Otherwise they must be coming from the subject search #}
-  {% else %}
-    If you have selected a qualification type and level, detail your expertise for your subject at the qualification type and level(s). 
-  {% endif %}
-{% endset %}
-
 {% set expertiseAreasHtml %}
     {# Build an list of the items selected #}
     {% if data.referrer == "sectorSearch" %}
@@ -98,10 +88,6 @@
 
   {{ expertiseAreasHtml | safe }}
 
-  <p class="govuk-body">
-    {{ pageDescription2 }}
-  </p>
-
   {# If they are coming through the select a sector flow #}
   {% if data.referrer == "sectorSearch" %}
 
@@ -111,7 +97,10 @@
       label: {
         text: pageHeading,
         classes: "govuk-label--m"
-      }
+      },
+      hint: {
+        text: "If you have selected a qualification type and level, detail your expertise for your subject at the qualification type and level(s)."
+      } 
     } | decorateAttributes(data, "data.sectorExpertiseDetails")) }} 
   
   {# else they must be coming through subejct flow #}
@@ -123,7 +112,10 @@
       label: {
         text: pageHeading,
         classes: "govuk-label--m"
-      }
+      },
+      hint: {
+        text: "If you have selected a qualification type and level, detail your expertise for your subject at the qualification type and level(s)."
+      } 
     } | decorateAttributes(data, "data.subjectExpertiseDetails")) }} 
 
   {% endif %}


### PR DESCRIPTION
Flow wasn't working when only one type of expertise was selected. It was going straight to the review screen and skipping the add details box. 