### PR TITLE
Messages split

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -1283,6 +1283,9 @@ var acceptedRejected = {
   "teachingTrainingDetails": "Employer / Industry asbestos training. Commercial training provider. I would include here a specific summary of my training experience. I would link my work history and my roles and responsibilities and work done to these specific areas as you have directed.",
   "teachingTeacherTrainingDetails": "Train asbestos training providers. Training other trainers. I would include here a specific summary of my experience training others. I would link my work history and my roles and responsibilities and work done to these specific areas as you have directed.",
   "teachingExpertiseCompleted": "complete",
+  "teachingStatus": "Action required",
+  "teachingAction": "Further evidence needed for your subject experience",
+  "teachingActionLink": "/account/messages/further-evidence-required-teaching",
 
   // Communication and analytical judgement skills
   "communicationDetails": "I would include here any extra details about my communication and analytical judgement skills I have not already covered.",
@@ -1412,6 +1415,7 @@ module.exports = {
   // set account messages status
   "proofNameChangeReply": "noReply",
   "subjectEvidenceReply": "noReply",
+  "teachingEvidenceReply": "noReply",
   "messageSent": "none",
   "applicationStatus": "incomplete",
   "accountMessageSubject": "",

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -32,7 +32,7 @@ var settings = {
 var completedApplicationDataVTQ = {
 
   // Personal details
-  "fullName": "Hans Kuhlman",
+  "fullName": "Hans Bowser",
   "email": "hans@email.com",
   "telephone": "07701123123",
   "whereDoYouLive": "In the UK",
@@ -457,7 +457,7 @@ var fillSubjectsData = {
 var awaitingDecision = {
 
   // Personal details
-  "fullName": "Hans Kuhlman",
+  "fullName": "Hans Bowser",
   "email": "hans@email.com",
   "telephone": "07701123123",
   "whereDoYouLive": "In the UK",
@@ -622,7 +622,7 @@ var awaitingDecision = {
 var actionRequired = {
 
   // Personal details
-  "fullName": "Hans Kuhlman",
+  "fullName": "Hans Bowser",
   "email": "hans@email.com",
   "telephone": "07701123123",
   "whereDoYouLive": "In the UK",
@@ -696,7 +696,41 @@ var actionRequired = {
   "isTeacherTraining": "true",
   "adviseAreasCompleted": "complete",
   // Subject2
-  "selectedSubject2": "",
+  "subject2": "true", 
+  "selectedSubject2": "Building control surveyor (integrated degree) (End-point assessment - level 6)",
+  "resultName2": "Building control surveyor (integrated degree)",
+  "selectedQualification2": "End-Point Assessment",
+  "selectedLevel2": [
+    "6"
+  ],
+  "expertiseType2": [
+    "Assessment",
+    "Industry, occupational or professional",
+    "Teaching, lecturing or training"
+  ],
+  "isAssessment2": "true",  
+  "assessmentExpertiseType2": [
+    "Making assessment judgements",
+    "Standard setting and awarding qualifications",
+    "Designing and developing assessments",
+    "Evaluating assessments or assessment approaches"
+  ],
+  "isJudgement2": "true",
+  "isStandardSetting2": "true",
+  "isDesigning2": "true",
+  "isEvaluating2": "true",
+  "isIndustry2": "true",
+  "isTeaching2": "true",  
+  "teachingExpertiseType2": [
+    "Teaching or lecturing",
+    "Training",
+    "Educational management",
+    "Teacher training"
+  ],
+  "isLecturing2": "true",
+  "isTraining2": "true",
+  "isEducationalManagement2": "true",
+  "isTeacherTraining2": "true",
 
   // Evidence of experience
   // Assessment experience
@@ -752,21 +786,23 @@ var actionRequired = {
   
   // Application status
   "applicationStatus": "Action required",
-  "applicationAction": "Further evidence needed for your subject experience",
-  "applicationActionLink": "/account/messages/further-evidence-required",
+  "applicationAction": "Further evidence needed for your experience in making assessment judgements",
+  "applicationActionLink": "/message-further-evidence",
+  "applicationAction2": "Further evidence needed for your experience in teacher training",
+  "applicationActionLink2": "/message-further-evidence-ttraining",
   "applicationFeedbackCategory": "",
   "applicationFeedback": "",
   // Subject 1
   "subject1AssessmentMakingStatus": "Action required", 
   "subject1AssessmentMakingFeedbackCategory": "",
   "subject1AssessmentMakingFeedback": "",
-  "subject1AssessmentSettingStatus": "Action required", 
+  "subject1AssessmentSettingStatus": "Awaiting decision", 
   "subject1AssessmentSettingFeedbackCategory": "",
   "subject1AssessmentSettingFeedback": "",
-  "subject1AssessmentDesigningStatus": "Action required", 
+  "subject1AssessmentDesigningStatus": "Awaiting decision", 
   "subject1AssessmentDesigningFeedbackCategory": "",
   "subject1AssessmentDesigningFeedback": "",
-  "subject1AssessmentEvaluatingStatus": "Action required", 
+  "subject1AssessmentEvaluatingStatus": "Awaiting decision", 
   "subject1AssessmentEvaluatingFeedbackCategory": "",
   "subject1AssessmentEvaluatingFeedback": "",
   "subject1IndustryStatus": "Awaiting decision", 
@@ -783,12 +819,40 @@ var actionRequired = {
   "subject1TeachingEducationalFeedback": "",
   "subject1TeachingTeacherTrainingStatus": "Awaiting decision", 
   "subject1TeachingTeacherTrainingFeedbackCategory": "",
-  "subject1TeachingTeacherTrainingFeedback": ""
+  "subject1TeachingTeacherTrainingFeedback": "",
+  // Subject 2
+  "subject2AssessmentMakingStatus": "Awaiting decision", 
+  "subject2AssessmentMakingFeedbackCategory": "",
+  "subject2AssessmentMakingFeedback": "",
+  "subject2AssessmentSettingStatus": "Awaiting decision", 
+  "subject2AssessmentSettingFeedbackCategory": "",
+  "subject2AssessmentSettingFeedback": "",
+  "subject2AssessmentDesigningStatus": "Awaiting decision", 
+  "subject2AssessmentDesigningFeedbackCategory": "",
+  "subject2AssessmentDesigningFeedback": "",
+  "subject2AssessmentEvaluatingStatus": "Awaiting decision", 
+  "subject2AssessmentEvaluatingFeedbackCategory": "",
+  "subject2AssessmentEvaluatingFeedback": "",
+  "subject2IndustryStatus": "Awaiting decision", 
+  "subject2IndustryFeedbackCategory": "",
+  "subject2IndustryFeedback": "",
+  "subject2TeachingTeachingStatus": "Awaiting decision", 
+  "subject2TeachingTeachingFeedbackCategory": "",
+  "subject2TeachingTeachingFeedback": "",
+  "subject2TeachingTrainingStatus": "Awaiting decision", 
+  "subject2TeachingTrainingFeedbackCategory": "",
+  "subject2TeachingTrainingFeedback": "",
+  "subject2TeachingEducationalStatus": "Awaiting decision", 
+  "subject2TeachingEducationalFeedbackCategory": "",
+  "subject2TeachingEducationalFeedback": "",
+  "subject2TeachingTeacherTrainingStatus": "Action required", 
+  "subject2TeachingTeacherTrainingFeedbackCategory": "",
+  "subject2TeachingTeacherTrainingFeedback": ""
 }
 
 var allAccepted = {
   // Personal details
-  "fullName": "Hans Kuhlman",
+  "fullName": "Hans Bowser",
   "email": "hans@email.com",
   "telephone": "07701123123",
   "whereDoYouLive": "In the UK",
@@ -1016,7 +1080,7 @@ var allAccepted = {
 
 var allRejected = {
   // Personal details
-  "fullName": "Hans Kuhlman",
+  "fullName": "Hans Bowser",
   "email": "hans@email.com",
   "telephone": "07701123123",
   "whereDoYouLive": "In the UK",
@@ -1172,7 +1236,7 @@ var allRejected = {
 
 var acceptedRejected = {
   // Personal details
-  "fullName": "Hans Kuhlman",
+  "fullName": "Hans Bowser",
   "email": "hans@email.com",
   "telephone": "07701123123",
   "whereDoYouLive": "In the UK",
@@ -1285,7 +1349,7 @@ var acceptedRejected = {
   "teachingExpertiseCompleted": "complete",
   "teachingStatus": "Action required",
   "teachingAction": "Further evidence needed for your subject experience",
-  "teachingActionLink": "/account/messages/further-evidence-required-teaching",
+  "teachingActionLink": "/account/messages/further-evidence-required-ttraining",
 
   // Communication and analytical judgement skills
   "communicationDetails": "I would include here any extra details about my communication and analytical judgement skills I have not already covered.",
@@ -1419,7 +1483,8 @@ module.exports = {
   "messageSent": "none",
   "applicationStatus": "incomplete",
   "accountMessageSubject": "",
-  "accountMessageUnread": "Unread",
+  "accountMessageMakingJudgements": "Unread",
+  "accountMessageTeacherTraining": "Unread",
   // Subject2
   "selectedSubject2": ""
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -1058,7 +1058,14 @@ router.all('/change-self-declaration', function (req, res) {
 // Account - Messages - change unread status 
 router.all('/message-further-evidence', function (req, res) {
 
-  req.session.data.accountMessageUnread = "Read"
+  req.session.data.accountMessageMakingJudgements = "Read"
   res.redirect('/account/messages/further-evidence-required');
+  
+})
+
+router.all('/message-further-evidence-ttraining', function (req, res) {
+
+  req.session.data.accountMessageTeacherTraining = "Read"
+  res.redirect('/account/messages/further-evidence-required-ttraining');
   
 })

--- a/app/views/_includes/summary-cards/application-status.html
+++ b/app/views/_includes/summary-cards/application-status.html
@@ -3,13 +3,20 @@
   {% endset %}
   
   {% set actionRequiredHtml %}
-    {% if data.proofNameChangeReply == "replied" %}
+    {% if data.subjectEvidenceReply == "replied" %}
       <p class="govuk-body-s govuk-!-margin-bottom-1">You replied <time datetime="">{{ "" | today |  govukDate }}</time></p>
     {% else %}
       <p class="govuk-body-s govuk-!-margin-bottom-1 "><time datetime="">{{ "" | yesterday |  govukDate }}</time></p>
     {% endif %}
     <h4 class="govuk-!-margin-top-1 govuk-!-margin-bottom-1">{{ data.applicationAction }}</h4>
     <p><a href="{{ data.applicationActionLink }}">View message</a></p>
+    {% if data.teachingEvidenceReply == "replied" %}
+      <p class="govuk-body-s govuk-!-margin-bottom-1">You replied <time datetime="">{{ "" | today |  govukDate }}</time></p>
+    {% else %}
+      <p class="govuk-body-s govuk-!-margin-bottom-1 "><time datetime="">{{ "" | yesterday |  govukDate }}</time></p>
+    {% endif %}
+    <h4 class="govuk-!-margin-top-1 govuk-!-margin-bottom-1">{{ data.applicationAction2 }}</h4>
+    <p><a href="{{ data.applicationActionLink2 }}">View message</a></p>
   {% endset %}
 
   {% set rejectedFeedbackHtml %}

--- a/app/views/_includes/summary-cards/subject-status.html
+++ b/app/views/_includes/summary-cards/subject-status.html
@@ -1,5 +1,5 @@
   {% set actionRequiredHtml %}
-    {% if data.proofNameChangeReply == "replied" %}
+    {% if data.subjectEvidenceReply == "replied" %}
       <p class="govuk-body-s govuk-!-margin-bottom-1">You replied <time datetime="">{{ "" | today |  govukDate }}</time></p>
     {% else %}
       <p class="govuk-body-s govuk-!-margin-bottom-1 "><time datetime="">{{ "" | yesterday |  govukDate }}</time></p>
@@ -8,14 +8,14 @@
     <p><a href="{{ data.applicationActionLink }}">View message</a></p>
   {% endset %}
 
-  {% set actionRequiredTeachingHtml %}
+  {% set actionRequiredTTrainingHtml %}
     {% if data.teachingEvidenceReply == "replied" %}
       <p class="govuk-body-s govuk-!-margin-bottom-1">You replied <time datetime="">{{ "" | today |  govukDate }}</time></p>
     {% else %}
       <p class="govuk-body-s govuk-!-margin-bottom-1 "><time datetime="">{{ "" | yesterday |  govukDate }}</time></p>
     {% endif %}
-    <h4 class="govuk-!-margin-top-1 govuk-!-margin-bottom-1">{{ data.teachingAction }}</h4>
-    <p><a href="{{ data.teachingActionLink }}">View message</a></p>
+    <h4 class="govuk-!-margin-top-1 govuk-!-margin-bottom-1">{{ data.applicationAction2 }}</h4>
+    <p><a href="{{ data.applicationActionLink2 }}">View message</a></p>
   {% endset %}
 
   <!-- START Card for subject 1 -->
@@ -492,7 +492,7 @@
               {% if data.subject1TeachingTeacherTrainingStatus == "Action required" %}
                 {{ govukDetails({
                   summaryText: "Further information required",
-                  html: actionRequiredHtml,
+                  html: actionRequiredTTrainingHtml,
                   classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
                 }) }} 
               {% elseif data.subject1TeachingTeacherTrainingStatus == "Rejected" %}
@@ -1017,7 +1017,7 @@
               {% if data.subject2TeachingTeacherTrainingStatus == "Action required" %}
                 {{ govukDetails({
                   summaryText: "Further information required",
-                  html: actionRequiredHtml,
+                  html: actionRequiredTTrainingHtml,
                   classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
                 }) }} 
               {% elseif data.subject2TeachingTeacherTrainingStatus == "Rejected" %}

--- a/app/views/_includes/summary-cards/subject-status.html
+++ b/app/views/_includes/summary-cards/subject-status.html
@@ -8,6 +8,16 @@
     <p><a href="{{ data.applicationActionLink }}">View message</a></p>
   {% endset %}
 
+  {% set actionRequiredTeachingHtml %}
+    {% if data.teachingEvidenceReply == "replied" %}
+      <p class="govuk-body-s govuk-!-margin-bottom-1">You replied <time datetime="">{{ "" | today |  govukDate }}</time></p>
+    {% else %}
+      <p class="govuk-body-s govuk-!-margin-bottom-1 "><time datetime="">{{ "" | yesterday |  govukDate }}</time></p>
+    {% endif %}
+    <h4 class="govuk-!-margin-top-1 govuk-!-margin-bottom-1">{{ data.teachingAction }}</h4>
+    <p><a href="{{ data.teachingActionLink }}">View message</a></p>
+  {% endset %}
+
   <!-- START Card for subject 1 -->
   <section class="x-govuk-summary-card">
     <header class="x-govuk-summary-card__header govuk-!-display-block govuk-!-margin-bottom-2">

--- a/app/views/account/messages/further-evidence-required-teaching.html
+++ b/app/views/account/messages/further-evidence-required-teaching.html
@@ -1,0 +1,51 @@
+{% extends "_templates/page-template.html" %}
+
+{% set pageHeading = "Further evidence needed for your teaching experience" %}
+{% set primaryNavActive = "Messages" %}
+{% set pageType = "Account" %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <span class="govuk-caption-l">24 Feb 2023 </span>
+      <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+      <p class="govuk-body">To proceed with your application we need more evidence of your experience in: </p>
+      <h2 class="govuk-heading-m"><span class="govuk-!-font-weight-bold">Teacher training</span> for Building control surveyor (integrated degree) (End-point assessment - level 6)</h2>
+      <p class="govuk-body">Please provide information and evidence (examples) about the following areas:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>teaching on a PGCE or similar course</li>
+        <li>co-tutoring or where you may have mentored trainee teachers or trainers</li>
+      </ul>
+      <p class="govuk-body govuk-!-margin-bottom-6"><a href="/account/your-details/application">View the evidence you've already provided </a></p>
+
+      {% if data.teachingEvidenceReply == "noReply" %}
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Reply to message",
+            href: "/account/messages/reply?referrer=teaching-evidence"
+          }) }}
+        </div>
+        {% else %} 
+      {% endif %}
+
+      {% if data.teachingEvidenceReply == "replied" %}
+        <hr>
+        <div class="govuk-!-margin-top-6">
+          <p class="govuk-caption-m govuk-!-margin-bottom-0">You replied 1 Mar 2023</p>
+          <h2 class="govuk-heading-l govuk-!-padding-top-0">Your reply</h2>
+          <p class="govuk-body">{{ data.accountMessageReplyTeachingEvidence }}</p>
+          <p class="govuk-body govuk-!-margin-bottom-6"><a href="#">{{ data.accountMessageReplyUploadTeachingEvidence }}</a></p>
+        </div>
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Send another reply",
+            href: "/account/messages/reply?referrer=teaching-evidence"
+          }) }}
+        </div>
+        {% else %} 
+      {% endif %}
+    </div>
+  </div>  
+
+{% endblock %}

--- a/app/views/account/messages/further-evidence-required-ttraining.html
+++ b/app/views/account/messages/further-evidence-required-ttraining.html
@@ -1,6 +1,6 @@
 {% extends "_templates/page-template.html" %}
 
-{% set pageHeading = "Further evidence needed for your teaching experience" %}
+{% set pageHeading = "Further evidence needed for your experience in teacher training" %}
 {% set primaryNavActive = "Messages" %}
 {% set pageType = "Account" %}
 

--- a/app/views/account/messages/further-evidence-required.html
+++ b/app/views/account/messages/further-evidence-required.html
@@ -1,6 +1,6 @@
 {% extends "_templates/page-template.html" %}
 
-{% set pageHeading = "Further evidence needed for your subject experience" %}
+{% set pageHeading = "Further evidence needed for your experience in making assessment judgements" %}
 {% set primaryNavActive = "Messages" %}
 {% set pageType = "Account" %}
 

--- a/app/views/account/messages/further-evidence-required.html
+++ b/app/views/account/messages/further-evidence-required.html
@@ -27,12 +27,6 @@
         <li>checking and verifying the marking of others, as a moderator within a school, college, for an awarding organisation or as an internal or external verifier</li>
       </ul>
 
-      <h2 class="govuk-heading-m"><span class="govuk-!-font-weight-bold">Teacher training</span> for Building control surveyor (integrated degree) (End-point assessment - level 6)</h2>
-      <p class="govuk-body">Please provide information and evidence (examples) about the following areas:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>teaching on a PGCE or similar course</li>
-        <li>co-tutoring or where you may have mentored trainee teachers or trainers</li>
-      </ul>
       <p class="govuk-body govuk-!-margin-bottom-6"><a href="/account/your-details/application">View the evidence you've already provided </a></p>
 
       {% if data.subjectEvidenceReply == "noReply" %}

--- a/app/views/account/messages/index.html
+++ b/app/views/account/messages/index.html
@@ -96,23 +96,75 @@
                 <div>&nbsp;</div>
               </td>
             </tr>
-          {% else %}
-            <tr class="govuk-table__row clickable-row message unread govuk-!-font-weight-bold">
+            {% else %}
+              <tr class="govuk-table__row clickable-row message unread govuk-!-font-weight-bold">
+                <!-- status -->
+                <td class="govuk-table__cell messages--govuk-table__cell messages--marker-column">
+                  <span class="messages--marker-column__marker messages--message-status-marker">Unread</span>
+                  <div>&nbsp;</div>
+                </td>
+                <!-- sender -->
+                <td class="govuk-table__cell messages--govuk-table__cell">
+                  <div class="message unread message-subject govuk-body govuk-!-margin-bottom-1">
+                    <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
+                      <a href="/message-further-evidence" class="govuk-!-font-weight-bold no--underline message-subject govuk-link" data-sso="false" lang="en">
+                        Further evidence needed for your subject experience
+                      </a>
+                    </h2>
+                  </div>
+                </td>
+              <!-- date -->
+              <td valign="top" class="messages--govuk-table__cell_last bold">
+                <time datetime="">{{ "" | yesterday |  govukDate }}</time>
+                <div>&nbsp;</div>
+              </td>
+            </tr>
+          {% endif %}
+          {% if data.accountMessageUnread == "Read" %}
+            <tr class="govuk-table__row clickable-row message read">
               <!-- status -->
-              <td class="govuk-table__cell messages--govuk-table__cell messages--marker-column">
-                <span class="messages--marker-column__marker messages--message-status-marker">Unread</span>
+              <td valign="top" class="govuk-table__cell messages--govuk-table__cell messages--marker-column">
                 <div>&nbsp;</div>
               </td>
               <!-- sender -->
               <td class="govuk-table__cell messages--govuk-table__cell">
-                <div class="message unread message-subject govuk-body govuk-!-margin-bottom-1">
-                  <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
-                    <a href="/message-further-evidence" class="govuk-!-font-weight-bold no--underline message-subject govuk-link" data-sso="false" lang="en">
-                      Further evidence needed for your subject experience
+                {% if data.teachingEvidenceReply == "replied" %}
+                  <div class="message read message-subject govuk-body govuk-!-margin-bottom-1">
+                    <p class="govuk-body-s govuk-!-margin-bottom-1">You replied <time datetime="">{{ "" | today |  govukDate }}</time></p>
+                  </div>
+                  {% else %}                
+                {% endif %}
+                <div class="message read message-subject govuk-body govuk-!-margin-bottom-1">
+                  <h2 class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-bottom-1">
+                    <a href="./messages/further-evidence-required-teaching" class="no--underline message-subject govuk-link" data-sso="false" lang="en">
+                      Further evidence needed for your teaching experience
                     </a>
                   </h2>
                 </div>
               </td>
+              <!-- date -->
+              <td valign="top" class="messages--govuk-table__cell_last bold">
+                <time datetime="">{{ "" | yesterday |  govukDate }}</time>
+                <div>&nbsp;</div>
+              </td>
+            </tr>
+          {% else %}
+              <tr class="govuk-table__row clickable-row message unread govuk-!-font-weight-bold">
+                <!-- status -->
+                <td class="govuk-table__cell messages--govuk-table__cell messages--marker-column">
+                  <span class="messages--marker-column__marker messages--message-status-marker">Unread</span>
+                  <div>&nbsp;</div>
+                </td>
+                <!-- sender -->
+                <td class="govuk-table__cell messages--govuk-table__cell">
+                  <div class="message unread message-subject govuk-body govuk-!-margin-bottom-1">
+                    <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
+                      <a href="./messages/further-evidence-required-teaching" class="govuk-!-font-weight-bold no--underline message-subject govuk-link" data-sso="false" lang="en">
+                        Further evidence needed for your teaching experience
+                      </a>
+                    </h2>
+                  </div>
+                </td>
               <!-- date -->
               <td valign="top" class="messages--govuk-table__cell_last bold">
                 <time datetime="">{{ "" | yesterday |  govukDate }}</time>

--- a/app/views/account/messages/index.html
+++ b/app/views/account/messages/index.html
@@ -68,7 +68,7 @@
           {% else %}
           {% endif %}
           
-          {% if data.accountMessageUnread == "Read" %}
+          {% if data.accountMessageMakingJudgements == "Read" %}
             <tr class="govuk-table__row clickable-row message read">
               <!-- status -->
               <td valign="top" class="govuk-table__cell messages--govuk-table__cell messages--marker-column">
@@ -85,7 +85,7 @@
                 <div class="message read message-subject govuk-body govuk-!-margin-bottom-1">
                   <h2 class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-bottom-1">
                     <a href="/message-further-evidence" class="no--underline message-subject govuk-link" data-sso="false" lang="en">
-                      Further evidence needed for your subject experience
+                      Further evidence needed for your experience in making assessment judgements
                     </a>
                   </h2>
                 </div>
@@ -108,7 +108,7 @@
                   <div class="message unread message-subject govuk-body govuk-!-margin-bottom-1">
                     <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
                       <a href="/message-further-evidence" class="govuk-!-font-weight-bold no--underline message-subject govuk-link" data-sso="false" lang="en">
-                        Further evidence needed for your subject experience
+                        Further evidence needed for your experience in making assessment judgements
                       </a>
                     </h2>
                   </div>
@@ -120,7 +120,7 @@
               </td>
             </tr>
           {% endif %}
-          {% if data.accountMessageUnread == "Read" %}
+          {% if data.accountMessageTeacherTraining == "Read" %}
             <tr class="govuk-table__row clickable-row message read">
               <!-- status -->
               <td valign="top" class="govuk-table__cell messages--govuk-table__cell messages--marker-column">
@@ -136,8 +136,8 @@
                 {% endif %}
                 <div class="message read message-subject govuk-body govuk-!-margin-bottom-1">
                   <h2 class="govuk-heading-s govuk-!-font-weight-regular govuk-!-margin-bottom-1">
-                    <a href="./messages/further-evidence-required-teaching" class="no--underline message-subject govuk-link" data-sso="false" lang="en">
-                      Further evidence needed for your teaching experience
+                    <a href="/message-further-evidence-ttraining" class="no--underline message-subject govuk-link" data-sso="false" lang="en">
+                      Further evidence needed for your experience in teacher training
                     </a>
                   </h2>
                 </div>
@@ -159,8 +159,8 @@
                 <td class="govuk-table__cell messages--govuk-table__cell">
                   <div class="message unread message-subject govuk-body govuk-!-margin-bottom-1">
                     <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
-                      <a href="./messages/further-evidence-required-teaching" class="govuk-!-font-weight-bold no--underline message-subject govuk-link" data-sso="false" lang="en">
-                        Further evidence needed for your teaching experience
+                      <a href="/message-further-evidence-ttraining" class="govuk-!-font-weight-bold no--underline message-subject govuk-link" data-sso="false" lang="en">
+                        Further evidence needed for your experience in teacher training
                       </a>
                     </h2>
                   </div>

--- a/app/views/account/messages/reply.html
+++ b/app/views/account/messages/reply.html
@@ -13,6 +13,8 @@
       Proof of name change required
     {% elseif data.referrer == "subject-evidence"%}
       Further evidence needed for your subject experience
+      {% elseif data.referrer == "teaching-evidence"%}
+      Further evidence needed for your teaching experience
     {% else %}
     {% endif %}
   {% endset %}
@@ -44,13 +46,14 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>checking and verifying the marking of others, as a moderator within a school, college, for an awarding organisation or as an internal or external verifier</li>
       </ul>
-
-      <h2 class="govuk-heading-m"><span class="govuk-!-font-weight-bold">Teacher training</span> for Building control surveyor (integrated degree) (End-point assessment - level 6)</h2>
-      <p class="govuk-body">Please provide information and evidence (examples) about the following areas:</p>
-      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-        <li>teaching on a PGCE or similar course</li>
-        <li>co-tutoring or where you may have mentored trainee teachers or trainers</li>
-      </ul>
+    {% elseif data.referrer == "teaching-evidence"%}
+    <p class="govuk-body">To proceed with your application we need more evidence of your experience in: </p>
+    <h2 class="govuk-heading-m"><span class="govuk-!-font-weight-bold">Teacher training</span> for Building control surveyor (integrated degree) (End-point assessment - level 6)</h2>
+    <p class="govuk-body">Please provide information and evidence (examples) about the following areas:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>teaching on a PGCE or similar course</li>
+      <li>co-tutoring or where you may have mentored trainee teachers or trainers</li>
+    </ul>
     {% else %}
     {% endif %}
   {% endset %}
@@ -81,7 +84,8 @@
 
     {# This sets the reply status on the message list #}
     <input type="hidden" name="proofNameChangeReply" value="replied">
-    {% elseif data.referrer == "subject-evidence" %}
+
+  {% elseif data.referrer == "subject-evidence" %}
       {{ govukDetails({
         summaryText: "View the message you are replying to",
         html: detailsHtml
@@ -105,6 +109,31 @@
     
     {# This sets the reply status on the message list #}
     <input type="hidden" name="subjectEvidenceReply" value="replied">
+
+  {% elseif data.referrer == "teaching-evidence" %}
+    {{ govukDetails({
+      summaryText: "View the message you are replying to",
+      html: detailsHtml
+    }) }}
+
+    {{ govukCharacterCount({
+      maxwords: 500,
+      rows: "10",
+      label: {
+        text: "Your message",
+        classes: "govuk-label--m"
+      }
+    } | decorateAttributes(data, "data.accountMessageReplyTeachingEvidence")) }}
+
+    {{ govukFileUpload({
+      label: {
+        text: "Upload a file",
+        classes: "govuk-label--m"
+      }
+    } | decorateAttributes(data, "data.accountMessageReplyUploadTeachingEvidence")) }}
+  
+    {# This sets the reply status on the message list #}
+    <input type="hidden" name="teachingEvidenceReply" value="replied">
   {% else %}
   {% endif %}
   <div class="govuk-button-group">

--- a/app/views/account/messages/reply.html
+++ b/app/views/account/messages/reply.html
@@ -12,9 +12,9 @@
     {% if data.referrer == "name-change-proof"%}
       Proof of name change required
     {% elseif data.referrer == "subject-evidence"%}
-      Further evidence needed for your subject experience
+      Further evidence needed for your experience in making assessment judgements
       {% elseif data.referrer == "teaching-evidence"%}
-      Further evidence needed for your teaching experience
+      Further evidence needed for your experience in teacher training
     {% else %}
     {% endif %}
   {% endset %}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -113,9 +113,13 @@
                   <a class="govuk-header__link govuk-header__link__primary-nav" href="/account/messages?referrer=" {{'aria-current=page' if primaryNavActive == 'Messages'}}>
                     Messages
                   </a>
-                  {% if data.accountMessageUnread == "Unread" %}
+                  {% if (data.accountMessageMakingJudgements == "Unread") and (data.accountMessageTeacherTraining == "Unread") %}
                     <span class="app-notification-number">2</span>
-                  {% else %}
+                    {% elseif data.accountMessageMakingJudgements == "Unread" %}
+                    <span class="app-notification-number">1</span>
+                    {% elseif data.accountMessageTeacherTraining == "Unread" %}
+                      <span class="app-notification-number">1</span>
+                    {% else %}
                   {% endif %} 
                 </li>
                 <li class="govuk-header__navigation-item govuk-header__navigation-item__primary-nav">

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -114,7 +114,7 @@
                     Messages
                   </a>
                   {% if data.accountMessageUnread == "Unread" %}
-                    <span class="app-notification-number">1</span>
+                    <span class="app-notification-number">2</span>
                   {% else %}
                   {% endif %} 
                 </li>


### PR DESCRIPTION
This branch has the same bug as the application scenarios. The 'you replied' text only comes up if the top message has been replied to.

In the application status box,  the 'view message' anchor goes to 'Further evidence needed for your subject experience'. Does a new link need to be added here to access the other message?