### PR TITLE
Updates to status box for approved applications. 

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -525,11 +525,43 @@ var awaitingDecision = {
   "isTeaching": "true",  
   "teachingExpertiseType": [
     "Training",
-    "Teacher training"
   ],
   "isTraining": "true",
-  "isTeacherTraining": "true",
   "adviseAreasCompleted": "complete",
+  // Subject2
+  "subject2": "true", 
+  "selectedSubject2": "Building control surveyor (integrated degree) (End-point assessment - level 6)",
+  "resultName2": "Building control surveyor (integrated degree)",
+  "selectedQualification2": "End-Point Assessment",
+  "selectedLevel2": [
+    "6"
+  ],
+  "expertiseType2": [
+    "Assessment",
+    "Industry, occupational or professional",
+    "Teaching, lecturing or training"
+  ],
+  "isAssessment2": "true",  
+  "assessmentExpertiseType2": [
+    "Making assessment judgements",
+    "Standard setting and awarding qualifications",
+    "Designing and developing assessments",
+    "Evaluating assessments or assessment approaches"
+  ],
+  "isJudgement2": "true",
+  "isStandardSetting2": "true",
+  "isDesigning2": "true",
+  "isEvaluating2": "true",
+  "isIndustry2": "true",
+  "isTeaching2": "true",  
+  "teachingExpertiseType2": [
+    "Teaching or lecturing",
+    "Training",
+    "Educational management",
+  ],
+  "isLecturing2": "true",
+  "isTraining2": "true",
+  "isEducationalManagement2": "true",
 
   // Evidence of experience
   // Assessment experience
@@ -590,6 +622,9 @@ var awaitingDecision = {
   "applicationFeedbackCategory": "",
   "applicationFeedback": "",
   // Subject 1
+  "subject1Status": "Awaiting decision", 
+  "subject1FeedbackCategory": "",
+  "subject1Feedback": "",
   "subject1AssessmentMakingStatus": "Awaiting decision", 
   "subject1AssessmentMakingFeedbackCategory": "",
   "subject1AssessmentMakingFeedback": "",
@@ -614,9 +649,40 @@ var awaitingDecision = {
   "subject1TeachingEducationalStatus": "", 
   "subject1TeachingEducationalFeedbackCategory": "",
   "subject1TeachingEducationalFeedback": "",
-  "subject1TeachingTeacherTrainingStatus": "Awaiting decision", 
+  "subject1TeachingTeacherTrainingStatus": "", 
   "subject1TeachingTeacherTrainingFeedbackCategory": "",
-  "subject1TeachingTeacherTrainingFeedback": ""
+  "subject1TeachingTeacherTrainingFeedback": "",
+  // Subject 2
+  "subject2Status": "Awaiting decision", 
+  "subject2FeedbackCategory": "",
+  "subject2Feedback": "",
+  "subject2AssessmentMakingStatus": "Awaiting decision", 
+  "subject2AssessmentMakingFeedbackCategory": "",
+  "subject2AssessmentMakingFeedback": "",
+  "subject2AssessmentSettingStatus": "Awaiting decision", 
+  "subject2AssessmentSettingFeedbackCategory": "",
+  "subject2AssessmentSettingFeedback": "",
+  "subject2AssessmentDesigningStatus": "Awaiting decision", 
+  "subject2AssessmentDesigningFeedbackCategory": "",
+  "subject2AssessmentDesigningFeedback": "",
+  "subject2AssessmentEvaluatingStatus": "Awaiting decision", 
+  "subject2AssessmentEvaluatingFeedbackCategory": "",
+  "subject2AssessmentEvaluatingFeedback": "",
+  "subject2IndustryStatus": "Awaiting decision", 
+  "subject2IndustryFeedbackCategory": "",
+  "subject2IndustryFeedback": "",
+  "subject2TeachingTeachingStatus": "Awaiting decision", 
+  "subject2TeachingTeachingFeedbackCategory": "",
+  "subject2TeachingTeachingFeedback": "",
+  "subject2TeachingTrainingStatus": "Awaiting decision", 
+  "subject2TeachingTrainingFeedbackCategory": "",
+  "subject2TeachingTrainingFeedback": "",
+  "subject2TeachingEducationalStatus": "Awaiting decision", 
+  "subject2TeachingEducationalFeedbackCategory": "",
+  "subject2TeachingEducationalFeedback": "",
+  "subject2TeachingTeacherTrainingStatus": "", 
+  "subject2TeachingTeacherTrainingFeedbackCategory": "",
+  "subject2TeachingTeacherTrainingFeedback": "",
 }
 
 var actionRequired = {
@@ -663,74 +729,70 @@ var actionRequired = {
   "referenceOrganisation": "Engineering2 Limited (Chosen a colleague from an AO or someone from a professional membership)",
   "referencesCompleted": "complete",
 
-  // Subjects
-  "selectedSubject": "Asbestos (End-Point Assessment - Level 3)",
-  "resultName": "Asbestos Analyst and Surveyor",
-  "selectedQualification": "End-Point Assessment",
-  "selectedLevel": [
-    "3, 4"
-  ],
-  "expertiseType": [
-    "Assessment",
-    "Industry, occupational or professional",
-    "Teaching, lecturing or training"
-  ],
-  "isAssessment": "true",  
-  "assessmentExpertiseType": [
-    "Making assessment judgements",
-    "Standard setting and awarding qualifications",
-    "Designing and developing assessments",
-    "Evaluating assessments or assessment approaches"
-  ],
-  "isJudgement": "true",
-  "isStandardSetting": "true",
-  "isDesigning": "true",
-  "isEvaluating": "true",
-  "isIndustry": "true",
-  "isTeaching": "true",  
-  "teachingExpertiseType": [
-    "Training",
-    "Teacher training"
-  ],
-  "isTraining": "true",
-  "isTeacherTraining": "true",
-  "adviseAreasCompleted": "complete",
-  // Subject2
-  "subject2": "true", 
-  "selectedSubject2": "Building control surveyor (integrated degree) (End-point assessment - level 6)",
-  "resultName2": "Building control surveyor (integrated degree)",
-  "selectedQualification2": "End-Point Assessment",
-  "selectedLevel2": [
-    "6"
-  ],
-  "expertiseType2": [
-    "Assessment",
-    "Industry, occupational or professional",
-    "Teaching, lecturing or training"
-  ],
-  "isAssessment2": "true",  
-  "assessmentExpertiseType2": [
-    "Making assessment judgements",
-    "Standard setting and awarding qualifications",
-    "Designing and developing assessments",
-    "Evaluating assessments or assessment approaches"
-  ],
-  "isJudgement2": "true",
-  "isStandardSetting2": "true",
-  "isDesigning2": "true",
-  "isEvaluating2": "true",
-  "isIndustry2": "true",
-  "isTeaching2": "true",  
-  "teachingExpertiseType2": [
-    "Teaching or lecturing",
-    "Training",
-    "Educational management",
-    "Teacher training"
-  ],
-  "isLecturing2": "true",
-  "isTraining2": "true",
-  "isEducationalManagement2": "true",
-  "isTeacherTraining2": "true",
+   // Subjects
+   "selectedSubject": "Asbestos (End-Point Assessment - Level 3)",
+   "resultName": "Asbestos Analyst and Surveyor",
+   "selectedQualification": "End-Point Assessment",
+   "selectedLevel": [
+     "3, 4"
+   ],
+   "expertiseType": [
+     "Assessment",
+     "Industry, occupational or professional",
+     "Teaching, lecturing or training"
+   ],
+   "isAssessment": "true",  
+   "assessmentExpertiseType": [
+     "Making assessment judgements",
+     "Standard setting and awarding qualifications",
+     "Designing and developing assessments",
+     "Evaluating assessments or assessment approaches"
+   ],
+   "isJudgement": "true",
+   "isStandardSetting": "true",
+   "isDesigning": "true",
+   "isEvaluating": "true",
+   "isIndustry": "true",
+   "isTeaching": "true",  
+   "teachingExpertiseType": [
+     "Training",
+   ],
+   "isTraining": "true",
+   "adviseAreasCompleted": "complete",
+   // Subject2
+   "subject2": "true", 
+   "selectedSubject2": "Building control surveyor (integrated degree) (End-point assessment - level 6)",
+   "resultName2": "Building control surveyor (integrated degree)",
+   "selectedQualification2": "End-Point Assessment",
+   "selectedLevel2": [
+     "6"
+   ],
+   "expertiseType2": [
+     "Assessment",
+     "Industry, occupational or professional",
+     "Teaching, lecturing or training"
+   ],
+   "isAssessment2": "true",  
+   "assessmentExpertiseType2": [
+     "Making assessment judgements",
+     "Standard setting and awarding qualifications",
+     "Designing and developing assessments",
+     "Evaluating assessments or assessment approaches"
+   ],
+   "isJudgement2": "true",
+   "isStandardSetting2": "true",
+   "isDesigning2": "true",
+   "isEvaluating2": "true",
+   "isIndustry2": "true",
+   "isTeaching2": "true",  
+   "teachingExpertiseType2": [
+     "Teaching or lecturing",
+     "Training",
+     "Educational management",
+   ],
+   "isLecturing2": "true",
+   "isTraining2": "true",
+   "isEducationalManagement2": "true",
 
   // Evidence of experience
   // Assessment experience
@@ -796,6 +858,9 @@ var actionRequired = {
   "applicationFeedbackCategory": "",
   "applicationFeedback": "",
   // Subject 1
+  "subject1Status": "Action required", 
+  "subject1FeedbackCategory": "",
+  "subject1Feedback": "",
   "subject1AssessmentMakingStatus": "Action required", 
   "subject1AssessmentMakingFeedbackCategory": "",
   "subject1AssessmentMakingFeedback": "",
@@ -824,6 +889,9 @@ var actionRequired = {
   "subject1TeachingTeacherTrainingFeedbackCategory": "",
   "subject1TeachingTeacherTrainingFeedback": "",
   // Subject 2
+  "subject2Status": "Action required", 
+  "subject2FeedbackCategory": "",
+  "subject2Feedback": "",
   "subject2AssessmentMakingStatus": "Awaiting decision", 
   "subject2AssessmentMakingFeedbackCategory": "",
   "subject2AssessmentMakingFeedback": "",
@@ -900,74 +968,70 @@ var allAccepted = {
   "referenceOrganisation": "Engineering2 Limited (Chosen a colleague from an AO or someone from a professional membership)",
   "referencesCompleted": "complete",
 
-  // Subjects
-  "selectedSubject": "Asbestos (End-Point Assessment - Level 3)",
-  "resultName": "Asbestos Analyst and Surveyor",
-  "selectedQualification": "End-Point Assessment",
-  "selectedLevel": [
-    "3, 4"
-  ],
-  "expertiseType": [
-    "Assessment",
-    "Industry, occupational or professional",
-    "Teaching, lecturing or training"
-  ],
-  "isAssessment": "true",  
-  "assessmentExpertiseType": [
-    "Making assessment judgements",
-    "Standard setting and awarding qualifications",
-    "Designing and developing assessments",
-    "Evaluating assessments or assessment approaches"
-  ],
-  "isJudgement": "true",
-  "isStandardSetting": "true",
-  "isDesigning": "true",
-  "isEvaluating": "true",
-  "isIndustry": "true",
-  "isTeaching": "true",  
-  "teachingExpertiseType": [
-    "Training",
-    "Teacher training"
-  ],
-  "isTraining": "true",
-  "isTeacherTraining": "true",
-  "adviseAreasCompleted": "complete",
-  // Subject2
-  "subject2": "true", 
-  "selectedSubject2": "Building control surveyor (integrated degree) (End-point assessment - level 6)",
-  "resultName2": "Building control surveyor (integrated degree)",
-  "selectedQualification2": "End-Point Assessment",
-  "selectedLevel2": [
-    "6"
-  ],
-  "expertiseType2": [
-    "Assessment",
-    "Industry, occupational or professional",
-    "Teaching, lecturing or training"
-  ],
-  "isAssessment2": "true",  
-  "assessmentExpertiseType2": [
-    "Making assessment judgements",
-    "Standard setting and awarding qualifications",
-    "Designing and developing assessments",
-    "Evaluating assessments or assessment approaches"
-  ],
-  "isJudgement2": "true",
-  "isStandardSetting2": "true",
-  "isDesigning2": "true",
-  "isEvaluating2": "true",
-  "isIndustry2": "true",
-  "isTeaching2": "true",  
-  "teachingExpertiseType2": [
-    "Teaching or lecturing",
-    "Training",
-    "Educational management",
-    "Teacher training"
-  ],
-  "isLecturing2": "true",
-  "isTraining2": "true",
-  "isEducationalManagement2": "true",
-  "isTeacherTraining2": "true", 
+   // Subjects
+   "selectedSubject": "Asbestos (End-Point Assessment - Level 3)",
+   "resultName": "Asbestos Analyst and Surveyor",
+   "selectedQualification": "End-Point Assessment",
+   "selectedLevel": [
+     "3, 4"
+   ],
+   "expertiseType": [
+     "Assessment",
+     "Industry, occupational or professional",
+     "Teaching, lecturing or training"
+   ],
+   "isAssessment": "true",  
+   "assessmentExpertiseType": [
+     "Making assessment judgements",
+     "Standard setting and awarding qualifications",
+     "Designing and developing assessments",
+     "Evaluating assessments or assessment approaches"
+   ],
+   "isJudgement": "true",
+   "isStandardSetting": "true",
+   "isDesigning": "true",
+   "isEvaluating": "true",
+   "isIndustry": "true",
+   "isTeaching": "true",  
+   "teachingExpertiseType": [
+     "Training",
+   ],
+   "isTraining": "true",
+   "adviseAreasCompleted": "complete",
+   // Subject2
+   "subject2": "true", 
+   "selectedSubject2": "Building control surveyor (integrated degree) (End-point assessment - level 6)",
+   "resultName2": "Building control surveyor (integrated degree)",
+   "selectedQualification2": "End-Point Assessment",
+   "selectedLevel2": [
+     "6"
+   ],
+   "expertiseType2": [
+     "Assessment",
+     "Industry, occupational or professional",
+     "Teaching, lecturing or training"
+   ],
+   "isAssessment2": "true",  
+   "assessmentExpertiseType2": [
+     "Making assessment judgements",
+     "Standard setting and awarding qualifications",
+     "Designing and developing assessments",
+     "Evaluating assessments or assessment approaches"
+   ],
+   "isJudgement2": "true",
+   "isStandardSetting2": "true",
+   "isDesigning2": "true",
+   "isEvaluating2": "true",
+   "isIndustry2": "true",
+   "isTeaching2": "true",  
+   "teachingExpertiseType2": [
+     "Teaching or lecturing",
+     "Training",
+     "Educational management",
+   ],
+   "isLecturing2": "true",
+   "isTraining2": "true",
+   "isEducationalManagement2": "true",
 
   // Evidence of experience
   // Assessment experience
@@ -1028,6 +1092,9 @@ var allAccepted = {
   "applicationFeedbackCategory": "",
   "applicationFeedback": "",
   // Subject 1
+  "subject1Status": "Accepted", 
+  "subject1FeedbackCategory": "",
+  "subject1Feedback": "",
   "subject1AssessmentMakingStatus": "Accepted", 
   "subject1AssessmentMakingFeedbackCategory": "",
   "subject1AssessmentMakingFeedback": "",
@@ -1056,6 +1123,9 @@ var allAccepted = {
   "subject1TeachingTeacherTrainingFeedbackCategory": "",
   "subject1TeachingTeacherTrainingFeedback": "",
   // Subject 2
+  "subject2Status": "Accepted", 
+  "subject2FeedbackCategory": "",
+  "subject2Feedback": "",
   "subject2AssessmentMakingStatus": "Accepted", 
   "subject2AssessmentMakingFeedbackCategory": "",
   "subject2AssessmentMakingFeedback": "",
@@ -1133,30 +1203,70 @@ var allRejected = {
   "referenceOrganisation": "Engineering2 Limited (Chosen a colleague from an AO or someone from a professional membership)",
   "referencesCompleted": "complete",
 
-  // Subjects
-  "selectedSubject": "Asbestos (End-Point Assessment - Level 3)",
-  "resultName": "Asbestos Analyst and Surveyor",
-  "selectedQualification": "End-Point Assessment",
-  "selectedLevel": [
-    "Level 3"
-  ],
-  "expertiseType": [
-    "Assessment"
-  ],
-  "isAssessment": "true",  
-  "assessmentExpertiseType": [
-    "Making assessment judgements",
-    "Standard setting and awarding qualifications",
-    "Designing and developing assessments",
-    "Evaluating assessments or assessment approaches"
-  ],
-  "isJudgement": "true",
-  "isStandardSetting": "true",
-  "isDesigning": "true",
-  "isEvaluating": "true",
-  "adviseAreasCompleted": "complete",
-  // Subject2
-  "selectedSubject2": "",
+   // Subjects
+   "selectedSubject": "Asbestos (End-Point Assessment - Level 3)",
+   "resultName": "Asbestos Analyst and Surveyor",
+   "selectedQualification": "End-Point Assessment",
+   "selectedLevel": [
+     "3, 4"
+   ],
+   "expertiseType": [
+     "Assessment",
+     "Industry, occupational or professional",
+     "Teaching, lecturing or training"
+   ],
+   "isAssessment": "true",  
+   "assessmentExpertiseType": [
+     "Making assessment judgements",
+     "Standard setting and awarding qualifications",
+     "Designing and developing assessments",
+     "Evaluating assessments or assessment approaches"
+   ],
+   "isJudgement": "true",
+   "isStandardSetting": "true",
+   "isDesigning": "true",
+   "isEvaluating": "true",
+   "isIndustry": "true",
+   "isTeaching": "true",  
+   "teachingExpertiseType": [
+     "Training",
+   ],
+   "isTraining": "true",
+   "adviseAreasCompleted": "complete",
+   // Subject2
+   "subject2": "true", 
+   "selectedSubject2": "Building control surveyor (integrated degree) (End-point assessment - level 6)",
+   "resultName2": "Building control surveyor (integrated degree)",
+   "selectedQualification2": "End-Point Assessment",
+   "selectedLevel2": [
+     "6"
+   ],
+   "expertiseType2": [
+     "Assessment",
+     "Industry, occupational or professional",
+     "Teaching, lecturing or training"
+   ],
+   "isAssessment2": "true",  
+   "assessmentExpertiseType2": [
+     "Making assessment judgements",
+     "Standard setting and awarding qualifications",
+     "Designing and developing assessments",
+     "Evaluating assessments or assessment approaches"
+   ],
+   "isJudgement2": "true",
+   "isStandardSetting2": "true",
+   "isDesigning2": "true",
+   "isEvaluating2": "true",
+   "isIndustry2": "true",
+   "isTeaching2": "true",  
+   "teachingExpertiseType2": [
+     "Teaching or lecturing",
+     "Training",
+     "Educational management",
+   ],
+   "isLecturing2": "true",
+   "isTraining2": "true",
+   "isEducationalManagement2": "true",
 
   // Evidence of experience
   // Assessment experience
@@ -1214,9 +1324,12 @@ var allRejected = {
   "applicationStatus": "Rejected",
   "applicationAction": "",
   "applicationActionLink": "",
-  "applicationFeedbackCategory": "Qualifications not relevant",
-  "applicationFeedback": "This applicant does not have evidence of a qualification obtained that would give them experience to assess this subject.",
+  "applicationFeedbackCategory": "",
+  "applicationFeedback": "",
   // Subject 1
+  "subject1Status": "Rejected", 
+  "subject1FeedbackCategory": "Qualifications not relevant",
+  "subject1Feedback": "This applicant does not have evidence of a qualification obtained that would give them experience to assess this subject.",
   "subject1AssessmentMakingStatus": "Rejected", 
   "subject1AssessmentMakingFeedbackCategory": "",
   "subject1AssessmentMakingFeedback": "",
@@ -1229,13 +1342,13 @@ var allRejected = {
   "subject1AssessmentEvaluatingStatus": "Rejected", 
   "subject1AssessmentEvaluatingFeedbackCategory": "",
   "subject1AssessmentEvaluatingFeedback": "",
-  "subject1IndustryStatus": "", 
+  "subject1IndustryStatus": "Rejected", 
   "subject1IndustryFeedbackCategory": "",
   "subject1IndustryFeedback": "",
   "subject1TeachingTeachingStatus": "", 
   "subject1TeachingTeachingFeedbackCategory": "",
   "subject1TeachingTeachingFeedback": "",
-  "subject1TeachingTrainingStatus": "", 
+  "subject1TeachingTrainingStatus": "Rejected", 
   "subject1TeachingTrainingFeedbackCategory": "",
   "subject1TeachingTrainingFeedback": "",
   "subject1TeachingEducationalStatus": "", 
@@ -1244,6 +1357,38 @@ var allRejected = {
   "subject1TeachingTeacherTrainingStatus": "", 
   "subject1TeachingTeacherTrainingFeedbackCategory": "",
   "subject1TeachingTeacherTrainingFeedback": "",
+
+  // Subject 2
+  "subject2Status": "Rejected", 
+  "subject2FeedbackCategory": "Not enough experience",
+  "subject2Feedback": "We require a minimum of 3 years experience working in a subject to become a Subject Matter Specialist. This has not been evidenced in your application.",
+  "subject2AssessmentMakingStatus": "Rejected", 
+  "subject2AssessmentMakingFeedbackCategory": "",
+  "subject2AssessmentMakingFeedback": "",
+  "subject2AssessmentSettingStatus": "Rejected", 
+  "subject2AssessmentSettingFeedbackCategory": "",
+  "subject2AssessmentSettingFeedback": "",
+  "subject2AssessmentDesigningStatus": "Rejected", 
+  "subject2AssessmentDesigningFeedbackCategory": "",
+  "subject2AssessmentDesigningFeedback": "",
+  "subject2AssessmentEvaluatingStatus": "Rejected", 
+  "subject2AssessmentEvaluatingFeedbackCategory": "",
+  "subject2AssessmentEvaluatingFeedback": "",
+  "subject2IndustryStatus": "Rejected", 
+  "subject2IndustryFeedbackCategory": "",
+  "subject2IndustryFeedback": "",
+  "subject2TeachingTeachingStatus": "Rejected", 
+  "subject2TeachingTeachingFeedbackCategory": "",
+  "subject2TeachingTeachingFeedback": "",
+  "subject2TeachingTrainingStatus": "Rejected", 
+  "subject2TeachingTrainingFeedbackCategory": "",
+  "subject2TeachingTrainingFeedback": "",
+  "subject2TeachingEducationalStatus": "Rejected", 
+  "subject2TeachingEducationalFeedbackCategory": "",
+  "subject2TeachingEducationalFeedback": "",
+  "subject2TeachingTeacherTrainingStatus": "", 
+  "subject2TeachingTeacherTrainingFeedbackCategory": "",
+  "subject2TeachingTeacherTrainingFeedback": "",
 
   // Messages
   "accountMessageMakingJudgements": "Read",
@@ -1294,58 +1439,70 @@ var acceptedRejected = {
   "referenceOrganisation": "Engineering2 Limited (Chosen a colleague from an AO or someone from a professional membership)",
   "referencesCompleted": "complete",
 
-  // Subjects
-  "selectedSubject": "Asbestos (End-Point Assessment - Level 3)",
-  "resultName": "Asbestos Analyst and Surveyor",
-  "selectedQualification": "End-Point Assessment",
-  "selectedLevel": [
-    "3, 4"
-  ],
-  "expertiseType": [
-    "Assessment",
-    "Industry, occupational or professional",
-    "Teaching, lecturing or training"
-  ],
-  "isAssessment": "true",  
-  "assessmentExpertiseType": [
-    "Making assessment judgements",
-    "Standard setting and awarding qualifications",
-    "Designing and developing assessments",
-    "Evaluating assessments or assessment approaches"
-  ],
-  "isJudgement": "true",
-  "isStandardSetting": "true",
-  "isDesigning": "true",
-  "isEvaluating": "true",
-  "isIndustry": "true",
-  "isTeaching": "true",  
-  "teachingExpertiseType": [
-    "Training",
-    "Teacher training"
-  ],
-  "isTraining": "true",
-  "isTeacherTraining": "true", 
-  "adviseAreasCompleted": "complete", 
-  // Subject2
-  "subject2": "true", 
-  "selectedSubject2": "Building control surveyor (integrated degree) (End-point assessment - level 6)",
-  "resultName2": "Building control surveyor (integrated degree)",
-  "selectedQualification2": "End-Point Assessment",
-  "selectedLevel2": [
-    "6"
-  ],
-  "expertiseType2": [
-    "Assessment"
-  ],
-  "isAssessment2": "true",  
-  "assessmentExpertiseType2": [
-    "Making assessment judgements",
-    "Standard setting and awarding qualifications",
-    "Designing and developing assessments"
-  ],
-  "isJudgement2": "true",
-  "isStandardSetting2": "true",
-  "isDesigning2": "true",
+   // Subjects
+   "selectedSubject": "Asbestos (End-Point Assessment - Level 3)",
+   "resultName": "Asbestos Analyst and Surveyor",
+   "selectedQualification": "End-Point Assessment",
+   "selectedLevel": [
+     "3, 4"
+   ],
+   "expertiseType": [
+     "Assessment",
+     "Industry, occupational or professional",
+     "Teaching, lecturing or training"
+   ],
+   "isAssessment": "true",  
+   "assessmentExpertiseType": [
+     "Making assessment judgements",
+     "Standard setting and awarding qualifications",
+     "Designing and developing assessments",
+     "Evaluating assessments or assessment approaches"
+   ],
+   "isJudgement": "true",
+   "isStandardSetting": "true",
+   "isDesigning": "true",
+   "isEvaluating": "true",
+   "isIndustry": "true",
+   "isTeaching": "true",  
+   "teachingExpertiseType": [
+     "Training",
+   ],
+   "isTraining": "true",
+   "adviseAreasCompleted": "complete",
+   // Subject2
+   "subject2": "true", 
+   "selectedSubject2": "Building control surveyor (integrated degree) (End-point assessment - level 6)",
+   "resultName2": "Building control surveyor (integrated degree)",
+   "selectedQualification2": "End-Point Assessment",
+   "selectedLevel2": [
+     "6"
+   ],
+   "expertiseType2": [
+     "Assessment",
+     "Industry, occupational or professional",
+     "Teaching, lecturing or training"
+   ],
+   "isAssessment2": "true",  
+   "assessmentExpertiseType2": [
+     "Making assessment judgements",
+     "Standard setting and awarding qualifications",
+     "Designing and developing assessments",
+     "Evaluating assessments or assessment approaches"
+   ],
+   "isJudgement2": "true",
+   "isStandardSetting2": "true",
+   "isDesigning2": "true",
+   "isEvaluating2": "true",
+   "isIndustry2": "true",
+   "isTeaching2": "true",  
+   "teachingExpertiseType2": [
+     "Teaching or lecturing",
+     "Training",
+     "Educational management",
+   ],
+   "isLecturing2": "true",
+   "isTraining2": "true",
+   "isEducationalManagement2": "true",
 
   // Evidence of experience
   // Assessment experience
@@ -1409,6 +1566,9 @@ var acceptedRejected = {
   "applicationFeedbackCategory": "",
   "applicationFeedback": "",
   // Subject 1
+  "subject1Status": "Accepted", 
+  "subject1FeedbackCategory": "",
+  "subject1Feedback": "",
   "subject1AssessmentMakingStatus": "Rejected", 
   "subject1AssessmentMakingFeedbackCategory": "Type of experience inappropriate",
   "subject1AssessmentMakingFeedback": "This applicant does not have enough experience in making assessment judgements for this subjects.",
@@ -1424,41 +1584,44 @@ var acceptedRejected = {
   "subject1IndustryStatus": "Rejected", 
   "subject1IndustryFeedbackCategory": "Type of experience inappropriate",
   "subject1IndustryFeedback": "The applicant does not have enough industry experience.",
-  "subject1TeachingTeachingStatus": "", 
+  "subject1TeachingTeachingStatus": "Rejected", 
   "subject1TeachingTeachingFeedbackCategory": "",
   "subject1TeachingTeachingFeedback": "",
   "subject1TeachingTrainingStatus": "Rejected", 
   "subject1TeachingTrainingFeedbackCategory": "Length or amount of experience not sufficient",
   "subject1TeachingTrainingFeedback": "The applicant does not have enough teacher training experience in this subject.",
-  "subject1TeachingEducationalStatus": "", 
+  "subject1TeachingEducationalStatus": "Rejected", 
   "subject1TeachingEducationalFeedbackCategory": "",
   "subject1TeachingEducationalFeedback": "",
   "subject1TeachingTeacherTrainingStatus": "Rejected", 
   "subject1TeachingTeacherTrainingFeedbackCategory": "Other",
   "subject1TeachingTeacherTrainingFeedback": "No evidence provided.",
   // Subject 2
+  "subject2Status": "Rejected", 
+  "subject2FeedbackCategory": "Qualifications not relevant",
+  "subject2Feedback": "This applicant does not have evidence of a qualification obtained in this subject.",
   "subject2AssessmentMakingStatus": "Rejected", 
-  "subject2AssessmentMakingFeedbackCategory": "Qualifications not relevant",
-  "subject2AssessmentMakingFeedback": "This applicant does not have evidence of a qualification obtained that would give them experience to assess this subject.",
+  "subject2AssessmentMakingFeedbackCategory": "",
+  "subject2AssessmentMakingFeedback": "",
   "subject2AssessmentSettingStatus": "Rejected", 
-  "subject2AssessmentSettingFeedbackCategory": "Qualifications not relevant",
-  "subject2AssessmentSettingFeedback": "This applicant does not have evidence of a qualification obtained that would give them experience to assess this subject.",
+  "subject2AssessmentSettingFeedbackCategory": "",
+  "subject2AssessmentSettingFeedback": "",
   "subject2AssessmentDesigningStatus": "Rejected", 
-  "subject2AssessmentDesigningFeedbackCategory": "Qualifications not relevant",
-  "subject2AssessmentDesigningFeedback": "This applicant does not have evidence of a qualification obtained that would give them experience to assess this subject.",
+  "subject2AssessmentDesigningFeedbackCategory": "",
+  "subject2AssessmentDesigningFeedback": "",
   "subject2AssessmentEvaluatingStatus": "Rejected", 
-  "subject2AssessmentEvaluatingFeedbackCategory": "Qualifications not relevant",
-  "subject2AssessmentEvaluatingFeedback": "This applicant does not have evidence of a qualification obtained that would give them experience to assess this subject.",
-  "subject2IndustryStatus": "", 
+  "subject2AssessmentEvaluatingFeedbackCategory": "",
+  "subject2AssessmentEvaluatingFeedback": "",
+  "subject2IndustryStatus": "Rejected", 
   "subject2IndustryFeedbackCategory": "",
   "subject2IndustryFeedback": "",
-  "subject2TeachingTeachingStatus": "", 
+  "subject2TeachingTeachingStatus": "Rejected", 
   "subject2TeachingTeachingFeedbackCategory": "",
   "subject2TeachingTeachingFeedback": "",
-  "subject2TeachingTrainingStatus": "", 
+  "subject2TeachingTrainingStatus": "Rejected", 
   "subject2TeachingTrainingFeedbackCategory": "",
   "subject2TeachingTrainingFeedback": "",
-  "subject2TeachingEducationalStatus": "", 
+  "subject2TeachingEducationalStatus": "Rejected", 
   "subject2TeachingEducationalFeedbackCategory": "",
   "subject2TeachingEducationalFeedback": "",
   "subject2TeachingTeacherTrainingStatus": "", 

--- a/app/filters/dates.js
+++ b/app/filters/dates.js
@@ -85,6 +85,14 @@ filters.twoweeksago = () => {
   return twoweeksago
 }
 
+filters.threeyearstime = () => {
+  const todayDate = new Date()
+  const threeyearstime = new Date(todayDate)
+
+  threeyearstime.setDate(threeyearstime.getDate() + 1094)
+  return threeyearstime
+}
+
 /*
   ====================================================================
   todayGovuk

--- a/app/views/_includes/summary-cards/application-status.html
+++ b/app/views/_includes/summary-cards/application-status.html
@@ -1,5 +1,37 @@
+  {% set titleHtml %}
+    {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" %}
+      Your account 
+      {% else %}
+        Your application
+    {% endif %}
+  {% endset %}
+
+  {% set applicationStatusTitleHtml %}
+    {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" %}
+      Account status
+      {% else %}
+      Application status
+    {% endif %}
+  {% endset %}
+
+  {% set subjectStatusTitleHtml %}
+    {% if data.applicationStatus == "Accepted" %}
+      Approved subject or occupational areas
+      {% else %}
+      Status by subject or occupational areas
+    {% endif %}
+  {% endset %}
+  
   {% set applicationSubmittedTimeHtml %}
     <time datetime="">{{ "" | twoweeksago |  govukDate }}, 16:13</time>
+  {% endset %}
+
+  {% set applicationApprovalDateHtml %}
+    <time datetime="">{{ "" | yesterday |  govukDate }}</time>
+  {% endset %}
+
+  {% set applicationRenewalDateHtml %}
+    <time datetime="">{{ "" | threeyearstime |  govukDate }}</time>
   {% endset %}
   
   {% set actionRequiredHtml %}
@@ -56,7 +88,6 @@
         classes: "govuk-!-margin-top-4"
       }) }} 
     {% else %}
-      nothing
     {% endif %}
   {% endset %}
 
@@ -65,26 +96,26 @@
   {% endset %}
 
   {% set subjectStatusHtml %}
-    <a href="/account/your-details/subjects">View status by subject or occupational area</a>
+    <a href="/account/your-details/subjects">Subject or occupational areas</a>
   {% endset %}
 
 
   {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
   {{ xGovukSummaryCard({
-    titleText: "Your application",
+    titleText: titleHtml,
       actions: {
         items: [
           {
             href: "/account/your-details/application",
             text: "View application",
             visuallyHiddenText: "Your application"
-          } 
+          } if data.applicationStatus != "Accepted"
         ] if pageTypeSub != "Application"
       },
     rows: [
       {
         key: {
-          text: "Application status"
+          html: applicationStatusTitleHtml
         },
         value: {
           html: applicationStatusHtml
@@ -92,12 +123,12 @@
       },
       {
         key: {
-          text: "Status by subject or occupational area"
+          html: subjectStatusTitleHtml
         },
         value: {
           html: subjectStatusHtml
         }
-      } if data.applicationStatus == ("Accepted") or data.applicationStatus == ("Action required"),
+      } if data.applicationStatus != ("Awaiting decision"),
       {
         key: {
           text: "Last updated"
@@ -105,7 +136,7 @@
         value: {
           html: profileUpdatedHtml
         }
-      },
+      } if data.applicationStatus != "Accepted",
       {
         key: {
           text: "Date submitted"
@@ -113,6 +144,22 @@
         value: {
           html: applicationSubmittedTimeHtml
         }
-      }
+      } if data.applicationStatus != "Accepted",
+      {
+        key: {
+          text: "Date of approval"
+        },
+        value: {
+          html: applicationApprovalDateHtml
+        }
+      } if data.applicationStatus == "Accepted",
+      {
+        key: {
+          text: "Renewal date"
+        },
+        value: {
+          html: applicationRenewalDateHtml
+        }
+      } if data.applicationStatus == "Accepted"
     ]
   }) }}

--- a/app/views/_includes/summary-cards/personal-details.html
+++ b/app/views/_includes/summary-cards/personal-details.html
@@ -39,7 +39,7 @@
             visuallyHiddenText: "Telephone number",
             href: "/application/personal-details"
           }]
-        }
+        } 
       },
       {
         key: {
@@ -163,7 +163,7 @@
             visuallyHiddenText: "full name",
             href: "/account/your-details/personal-details/name"
           }]
-        }
+        } if pageTypeSub != "Application"
       }, 
       {
         key: {
@@ -178,7 +178,7 @@
             visuallyHiddenText: "Telephone number",
             href: "/account/your-details/personal-details/telephone"
           }]
-        }
+        } if pageTypeSub != "Application"
       },
       {
         key: {
@@ -193,7 +193,7 @@
             visuallyHiddenText: "email address",
             href: "/account/your-details/personal-details/email"
           }]
-        }
+        } if pageTypeSub != "Application"
       },
       {
         key: {
@@ -208,7 +208,7 @@
             visuallyHiddenText: "Country",
             href: "/account/your-details/personal-details/where-do-you-live"
           }]
-        }
+        } if pageTypeSub != "Application"
       },
       {
         key: {
@@ -223,7 +223,7 @@
             visuallyHiddenText: "address line 1",
             href: "/account/your-details/personal-details/contact-address"
           }]
-        }
+        } if pageTypeSub != "Application"
       }, 
       {
         key: {
@@ -238,7 +238,7 @@
             visuallyHiddenText: "address line 2",
             href: "/account/your-details/personal-details/contact-address"
           }]
-        }
+        } if pageTypeSub != "Application"
       }, 
       {
         key: {
@@ -253,7 +253,7 @@
             visuallyHiddenText: "town or city",
             href: "/account/your-details/personal-details/contact-address"
           }]
-        }
+        } if pageTypeSub != "Application"
       }, 
       {
         key: {
@@ -268,7 +268,7 @@
             visuallyHiddenText: "region, state or province",
             href: "/account/your-details/personal-details/contact-address"
           }]
-        }
+        } if pageTypeSub != "Application"
       } if data.whereDoYouLive == "Outside the UK",
       {
         key: {
@@ -283,7 +283,7 @@
             visuallyHiddenText: "county",
             href: "/account/your-details/personal-details/contact-address"
           }]
-        }
+        } if pageTypeSub != "Application"
       }]
     }) }}
   {% endif %}

--- a/app/views/_includes/summary-cards/subject-status.html
+++ b/app/views/_includes/summary-cards/subject-status.html
@@ -29,6 +29,8 @@
   {% endset %}
 
   <!-- START Card for subject 1 -->
+  {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject1Status == "Rejected" %}
+  {% else %}
   <section class="x-govuk-summary-card">
     <header class="x-govuk-summary-card__header govuk-!-display-block govuk-!-margin-bottom-2">
       <h2 class="x-govuk-summary-card__title govuk-!-font-size-24">
@@ -43,6 +45,8 @@
     </header>
     <!-- START of assessment -->
     {% if data.isAssessment == "true" %}
+      {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject1AssessmentMakingStatus == "Rejected" and data.subject1AssessmentSettingStatus == "Rejected" and data.subject1AssessmentDesigningStatus == "Rejected" and data.subject1AssessmentEvaluatingStatus == "Rejected" %}
+      {% else %}
       <header class="x-govuk-summary-card__header">
         <h2 class="x-govuk-summary-card__title">
           Assessment
@@ -52,282 +56,300 @@
         <dl class="govuk-summary-list">
         <!-- START row for Making assessment judgements -->
         {% if data.isJudgement == "true" %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
-              Making assessment judgements
-              {% if data.subject1AssessmentMakingStatus == "Action required" %}
-                {{ govukDetails({
-                  summaryText: "Further information required",
-                  html: actionRequiredHtml,
-                  classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
-                }) }} 
-              {% elseif data.subject1AssessmentMakingStatus == "Rejected" %}
-                <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                      Feedback
-                    </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject1AssessmentMakingFeedbackCategory }}</h4>
-                    <p class="govuk-body">{{ data.subject1AssessmentMakingFeedback }}</p>
-                  </div>
-                </details>
-              {% else %}
-            {% endif %}
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {% if data.subject1AssessmentMakingStatus == "Awaiting decision" %}
-                {{ govukTag({
-                  text: "Awaiting decision",
-                  classes: "govuk-tag--purple float-right"
-                })}}
-              {% elseif data.subject1AssessmentMakingStatus == "Action required" %}
-                {{ govukTag({
-                  text: "Action required",
-                  classes: "govuk-tag--yellow float-right"
-                })}}
-              {% elseif data.subject1AssessmentMakingStatus == "Accepted" %}
-                {{ govukTag({
-                  text: "Approved",
-                  classes: "govuk-tag--green float-right"
-                })}}
-              {% elseif data.subject1AssessmentMakingStatus == "Rejected" %}
-                {{ govukTag({
-                  text: "Rejected",
-                  classes: "govuk-tag--red float-right"
-                })}}
-              {% else %}
+          {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject1AssessmentMakingStatus == "Rejected" %}
+          {% else %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
+                Making assessment judgements
+                {% if data.subject1AssessmentMakingStatus == "Action required" %}
+                  {{ govukDetails({
+                    summaryText: "Further information required",
+                    html: actionRequiredHtml,
+                    classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
+                  }) }} 
+                {% elseif data.subject1AssessmentMakingStatus == "Rejected" %}
+                  <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        Feedback
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject1AssessmentMakingFeedbackCategory }}</h4>
+                      <p class="govuk-body">{{ data.subject1AssessmentMakingFeedback }}</p>
+                    </div>
+                  </details>
+                {% else %}
               {% endif %}
-            </dd>
-          </div>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {% if data.subject1AssessmentMakingStatus == "Awaiting decision" %}
+                  {{ govukTag({
+                    text: "Awaiting decision",
+                    classes: "govuk-tag--purple float-right"
+                  })}}
+                {% elseif data.subject1AssessmentMakingStatus == "Action required" %}
+                  {{ govukTag({
+                    text: "Action required",
+                    classes: "govuk-tag--yellow float-right"
+                  })}}
+                {% elseif data.subject1AssessmentMakingStatus == "Accepted" %}
+                  {{ govukTag({
+                    text: "Approved",
+                    classes: "govuk-tag--green float-right"
+                  })}}
+                {% elseif data.subject1AssessmentMakingStatus == "Rejected" %}
+                  {{ govukTag({
+                    text: "Rejected",
+                    classes: "govuk-tag--red float-right"
+                  })}}
+                {% else %}
+                {% endif %}
+              </dd>
+            </div>
+          {% endif %}
         {% endif %}
         <!-- END row for Making assessment judgements -->
         <!-- START row for Standard setting and awarding qualifications -->
         {% if data.isStandardSetting == "true" %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
-              Standard setting and awarding qualifications
-              {% if data.subject1AssessmentSettingStatus == "Action required" %}
-                {{ govukDetails({
-                  summaryText: "Further information required",
-                  html: actionRequiredHtml,
-                  classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
-                }) }} 
-              {% elseif data.subject1AssessmentSettingStatus == "Rejected" %}
-                <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                      Feedback
-                    </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject1AssessmentSettingFeedbackCategory }}</h4>
-                    <p class="govuk-body">{{ data.subject1AssessmentSettingFeedback }}</p>
-                  </div>
-                </details>
-              {% else %}
-            {% endif %}
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {% if data.subject1AssessmentSettingStatus == "Awaiting decision" %}
-                {{ govukTag({
-                  text: "Awaiting decision",
-                  classes: "govuk-tag--purple float-right"
-                })}}
-              {% elseif data.subject1AssessmentSettingStatus == "Action required" %}
-                {{ govukTag({
-                  text: "Action required",
-                  classes: "govuk-tag--yellow float-right"
-                })}}
-              {% elseif data.subject1AssessmentSettingStatus == "Accepted" %}
-                {{ govukTag({
-                  text: "Approved",
-                  classes: "govuk-tag--green float-right"
-                })}}
-              {% elseif data.subject1AssessmentSettingStatus == "Rejected" %}
-                {{ govukTag({
-                  text: "Rejected",
-                  classes: "govuk-tag--red float-right"
-                })}}
-              {% else %}
+          {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject1AssessmentSettingStatus == "Rejected" %}
+          {% else %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
+                Standard setting and awarding qualifications
+                {% if data.subject1AssessmentSettingStatus == "Action required" %}
+                  {{ govukDetails({
+                    summaryText: "Further information required",
+                    html: actionRequiredHtml,
+                    classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
+                  }) }} 
+                {% elseif data.subject1AssessmentSettingStatus == "Rejected" %}
+                  <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        Feedback
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject1AssessmentSettingFeedbackCategory }}</h4>
+                      <p class="govuk-body">{{ data.subject1AssessmentSettingFeedback }}</p>
+                    </div>
+                  </details>
+                {% else %}
               {% endif %}
-            </dd>
-          </div>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {% if data.subject1AssessmentSettingStatus == "Awaiting decision" %}
+                  {{ govukTag({
+                    text: "Awaiting decision",
+                    classes: "govuk-tag--purple float-right"
+                  })}}
+                {% elseif data.subject1AssessmentSettingStatus == "Action required" %}
+                  {{ govukTag({
+                    text: "Action required",
+                    classes: "govuk-tag--yellow float-right"
+                  })}}
+                {% elseif data.subject1AssessmentSettingStatus == "Accepted" %}
+                  {{ govukTag({
+                    text: "Approved",
+                    classes: "govuk-tag--green float-right"
+                  })}}
+                {% elseif data.subject1AssessmentSettingStatus == "Rejected" %}
+                  {{ govukTag({
+                    text: "Rejected",
+                    classes: "govuk-tag--red float-right"
+                  })}}
+                {% else %}
+                {% endif %}
+              </dd>
+            </div>
+          {% endif %}
         {% endif %}
         <!-- END row for Standard setting and awarding qualifications -->
         <!-- START row for Designing and developing assessments -->
         {% if data.isDesigning == "true" %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
-              Designing and developing assessments
-              {% if data.subject1AssessmentDesigningStatus == "Action required" %}
-                {{ govukDetails({
-                  summaryText: "Further information required",
-                  html: actionRequiredHtml,
-                  classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
-                }) }} 
-              {% elseif data.subject1AssessmentDesigningStatus == "Rejected" %}
-                <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                      Feedback
-                    </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject1AssessmentDesigningFeedbackCategory }}</h4>
-                    <p class="govuk-body">{{ data.subject1AssessmentDesigningFeedback }}</p>
-                  </div>
-                </details>
-              {% else %}
-            {% endif %}
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {% if data.subject1AssessmentDesigningStatus == "Awaiting decision" %}
-                {{ govukTag({
-                  text: "Awaiting decision",
-                  classes: "govuk-tag--purple float-right"
-                })}}
-              {% elseif data.subject1AssessmentDesigningStatus == "Action required" %}
-                {{ govukTag({
-                  text: "Action required",
-                  classes: "govuk-tag--yellow float-right"
-                })}}
-              {% elseif data.subject1AssessmentDesigningStatus == "Accepted" %}
-                {{ govukTag({
-                  text: "Approved",
-                  classes: "govuk-tag--green float-right"
-                })}}
-              {% elseif data.subject1AssessmentDesigningStatus == "Rejected" %}
-                {{ govukTag({
-                  text: "Rejected",
-                  classes: "govuk-tag--red float-right"
-                })}}
-              {% else %}
+          {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject1AssessmentDesigningStatus == "Rejected" %}
+          {% else %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
+                Designing and developing assessments
+                {% if data.subject1AssessmentDesigningStatus == "Action required" %}
+                  {{ govukDetails({
+                    summaryText: "Further information required",
+                    html: actionRequiredHtml,
+                    classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
+                  }) }} 
+                {% elseif data.subject1AssessmentDesigningStatus == "Rejected" %}
+                  <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        Feedback
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject1AssessmentDesigningFeedbackCategory }}</h4>
+                      <p class="govuk-body">{{ data.subject1AssessmentDesigningFeedback }}</p>
+                    </div>
+                  </details>
+                {% else %}
               {% endif %}
-            </dd>
-          </div>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {% if data.subject1AssessmentDesigningStatus == "Awaiting decision" %}
+                  {{ govukTag({
+                    text: "Awaiting decision",
+                    classes: "govuk-tag--purple float-right"
+                  })}}
+                {% elseif data.subject1AssessmentDesigningStatus == "Action required" %}
+                  {{ govukTag({
+                    text: "Action required",
+                    classes: "govuk-tag--yellow float-right"
+                  })}}
+                {% elseif data.subject1AssessmentDesigningStatus == "Accepted" %}
+                  {{ govukTag({
+                    text: "Approved",
+                    classes: "govuk-tag--green float-right"
+                  })}}
+                {% elseif data.subject1AssessmentDesigningStatus == "Rejected" %}
+                  {{ govukTag({
+                    text: "Rejected",
+                    classes: "govuk-tag--red float-right"
+                  })}}
+                {% else %}
+                {% endif %}
+              </dd>
+            </div>
+          {% endif %}
         {% endif %}
         <!-- END row for Designing and developing assessments -->
         <!-- START row for Evaluating assessments or assessment approaches -->
         {% if data.isEvaluating == "true" %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
-              Evaluating assessments or assessment approaches
-              {% if data.subject1AssessmentEvaluatingStatus == "Action required" %}
-                {{ govukDetails({
-                  summaryText: "Further information required",
-                  html: actionRequiredHtml,
-                  classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
-                }) }} 
-              {% elseif data.subject1AssessmentEvaluatingStatus == "Rejected" %}
-                <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                      Feedback
-                    </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject1AssessmentEvaluatingFeedbackCategory }}</h4>
-                    <p class="govuk-body">{{ data.subject1AssessmentEvaluatingFeedback }}</p>
-                  </div>
-                </details>
-              {% else %}
-            {% endif %}
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {% if data.subject1AssessmentEvaluatingStatus == "Awaiting decision" %}
-                {{ govukTag({
-                  text: "Awaiting decision",
-                  classes: "govuk-tag--purple float-right"
-                })}}
-              {% elseif data.subject1AssessmentEvaluatingStatus == "Action required" %}
-                {{ govukTag({
-                  text: "Action required",
-                  classes: "govuk-tag--yellow float-right"
-                })}}
-              {% elseif data.subject1AssessmentEvaluatingStatus == "Accepted" %}
-                {{ govukTag({
-                  text: "Approved",
-                  classes: "govuk-tag--green float-right"
-                })}}
-              {% elseif data.subject1AssessmentEvaluatingStatus == "Rejected" %}
-                {{ govukTag({
-                  text: "Rejected",
-                  classes: "govuk-tag--red float-right"
-                })}}
-              {% else %}
+          {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject1AssessmentEvaluatingStatus == "Rejected" %}
+          {% else %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
+                Evaluating assessments or assessment approaches
+                {% if data.subject1AssessmentEvaluatingStatus == "Action required" %}
+                  {{ govukDetails({
+                    summaryText: "Further information required",
+                    html: actionRequiredHtml,
+                    classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
+                  }) }} 
+                {% elseif data.subject1AssessmentEvaluatingStatus == "Rejected" %}
+                  <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        Feedback
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject1AssessmentEvaluatingFeedbackCategory }}</h4>
+                      <p class="govuk-body">{{ data.subject1AssessmentEvaluatingFeedback }}</p>
+                    </div>
+                  </details>
+                {% else %}
               {% endif %}
-            </dd>
-          </div>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {% if data.subject1AssessmentEvaluatingStatus == "Awaiting decision" %}
+                  {{ govukTag({
+                    text: "Awaiting decision",
+                    classes: "govuk-tag--purple float-right"
+                  })}}
+                {% elseif data.subject1AssessmentEvaluatingStatus == "Action required" %}
+                  {{ govukTag({
+                    text: "Action required",
+                    classes: "govuk-tag--yellow float-right"
+                  })}}
+                {% elseif data.subject1AssessmentEvaluatingStatus == "Accepted" %}
+                  {{ govukTag({
+                    text: "Approved",
+                    classes: "govuk-tag--green float-right"
+                  })}}
+                {% elseif data.subject1AssessmentEvaluatingStatus == "Rejected" %}
+                  {{ govukTag({
+                    text: "Rejected",
+                    classes: "govuk-tag--red float-right"
+                  })}}
+                {% else %}
+                {% endif %}
+              </dd>
+            </div>
+          {% endif %}
         {% endif %}
         <!-- END row for Evaluating assessments or assessment approaches -->
       </dl>
     </div>
+    {% endif %}
   {% endif %}
   <!-- START of Industry, occupational or professional -->
     {% if data.isIndustry == "true" %}
-      <header class="x-govuk-summary-card__header">
-        <h2 class="x-govuk-summary-card__title">
-          Industry, occupational or professional
-        </h2>
-      </header>
-      <div class="x-govuk-summary-card__body">
-        <dl class="govuk-summary-list">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters govuk-!-padding-bottom-0">
-              Industry, occupational or professional
-              {% if data.subject1IndustryStatus == "Action required" %}
-                {{ govukDetails({
-                  summaryText: "Further information required",
-                  html: actionRequiredHtml,
-                  classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
-                }) }} 
-              {% elseif data.subject1IndustryStatus == "Rejected" %}
-                <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                      Feedback
-                    </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject1IndustryFeedbackCategory }}</h4>
-                    <p class="govuk-body">{{ data.subject1IndustryFeedback }}</p>
-                  </div>
-                </details>
-              {% else %}
-            {% endif %}
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {% if data.subject1IndustryStatus == "Awaiting decision" %}
-                {{ govukTag({
-                  text: "Awaiting decision",
-                  classes: "govuk-tag--purple float-right"
-                })}}
-              {% elseif data.subject1IndustryStatus == "Action required" %}
-                {{ govukTag({
-                  text: "Action required",
-                  classes: "govuk-tag--yellow float-right"
-                })}}
-              {% elseif data.subject1IndustryStatus == "Accepted" %}
-                {{ govukTag({
-                  text: "Approved",
-                  classes: "govuk-tag--green float-right"
-                })}}
-              {% elseif data.subject1IndustryStatus == "Rejected" %}
-                {{ govukTag({
-                  text: "Rejected",
-                  classes: "govuk-tag--red float-right"
-                })}}
-              {% else %}
+      {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject1IndustryStatus == "Rejected" %}
+      {% else %}
+        <header class="x-govuk-summary-card__header">
+          <h2 class="x-govuk-summary-card__title">
+            Industry, occupational or professional
+          </h2>
+        </header>
+        <div class="x-govuk-summary-card__body">
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters govuk-!-padding-bottom-0">
+                Industry, occupational or professional
+                {% if data.subject1IndustryStatus == "Action required" %}
+                  {{ govukDetails({
+                    summaryText: "Further information required",
+                    html: actionRequiredHtml,
+                    classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
+                  }) }} 
+                {% elseif data.subject1IndustryStatus == "Rejected" %}
+                  <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        Feedback
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject1IndustryFeedbackCategory }}</h4>
+                      <p class="govuk-body">{{ data.subject1IndustryFeedback }}</p>
+                    </div>
+                  </details>
+                {% else %}
               {% endif %}
-            </dd>
-          </div>
-      </dl>
-    </div>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {% if data.subject1IndustryStatus == "Awaiting decision" %}
+                  {{ govukTag({
+                    text: "Awaiting decision",
+                    classes: "govuk-tag--purple float-right"
+                  })}}
+                {% elseif data.subject1IndustryStatus == "Action required" %}
+                  {{ govukTag({
+                    text: "Action required",
+                    classes: "govuk-tag--yellow float-right"
+                  })}}
+                {% elseif data.subject1IndustryStatus == "Accepted" %}
+                  {{ govukTag({
+                    text: "Approved",
+                    classes: "govuk-tag--green float-right"
+                  })}}
+                {% elseif data.subject1IndustryStatus == "Rejected" %}
+                  {{ govukTag({
+                    text: "Rejected",
+                    classes: "govuk-tag--red float-right"
+                  })}}
+                {% else %}
+                {% endif %}
+              </dd>
+            </div>
+        </dl>
+      </div>
+    {% endif %}
   {% endif %}
   <!-- START of Teaching, lecturing or training -->
     {% if data.isTeaching == "true" %}
+      {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject1TeachingTeachingStatus == "Rejected" and data.subject1TeachingTrainingStatus == "Rejected" and data.subject1TeachingEducationalStatus == "Rejected" and data.subject1TeachingTeacherTrainingStatus == "Rejected" %}
+      {% else %}
       <header class="x-govuk-summary-card__header">
         <h2 class="x-govuk-summary-card__title">
           Teaching, lecturing or training
@@ -337,223 +359,239 @@
         <dl class="govuk-summary-list">
         <!-- START row for Teaching or lecturing -->
         {% if data.isLecturing == "true" %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
-              Teaching or lecturing
-              {% if data.subject1TeachingTeachingStatus == "Action required" %}
-                {{ govukDetails({
-                  summaryText: "Further information required",
-                  html: actionRequiredHtml,
-                  classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
-                }) }} 
-              {% elseif data.subject1TeachingTeachingStatus == "Rejected" %}
-                <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                      Feedback
-                    </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject1TeachingTeachingFeedbackCategory }}</h4>
-                    <p class="govuk-body">{{ data.subject1TeachingTeachingFeedback }}</p>
-                  </div>
-                </details>
-              {% else %}
-            {% endif %}
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {% if data.subject1TeachingTeachingStatus == "Awaiting decision" %}
-                {{ govukTag({
-                  text: "Awaiting decision",
-                  classes: "govuk-tag--purple float-right"
-                })}}
-              {% elseif data.subject1TeachingTeachingStatus == "Action required" %}
-                {{ govukTag({
-                  text: "Action required",
-                  classes: "govuk-tag--yellow float-right"
-                })}}
-              {% elseif data.subject1TeachingTeachingStatus == "Accepted" %}
-                {{ govukTag({
-                  text: "Approved",
-                  classes: "govuk-tag--green float-right"
-                })}}
-              {% elseif data.subject1TeachingTeachingStatus == "Rejected" %}
-                {{ govukTag({
-                  text: "Rejected",
-                  classes: "govuk-tag--red float-right"
-                })}}
-              {% else %}
+          {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject1TeachingTeachingStatus == "Rejected" %}
+          {% else %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
+                Teaching or lecturing
+                {% if data.subject1TeachingTeachingStatus == "Action required" %}
+                  {{ govukDetails({
+                    summaryText: "Further information required",
+                    html: actionRequiredHtml,
+                    classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
+                  }) }} 
+                {% elseif data.subject1TeachingTeachingStatus == "Rejected" %}
+                  <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        Feedback
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject1TeachingTeachingFeedbackCategory }}</h4>
+                      <p class="govuk-body">{{ data.subject1TeachingTeachingFeedback }}</p>
+                    </div>
+                  </details>
+                {% else %}
               {% endif %}
-            </dd>
-          </div>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {% if data.subject1TeachingTeachingStatus == "Awaiting decision" %}
+                  {{ govukTag({
+                    text: "Awaiting decision",
+                    classes: "govuk-tag--purple float-right"
+                  })}}
+                {% elseif data.subject1TeachingTeachingStatus == "Action required" %}
+                  {{ govukTag({
+                    text: "Action required",
+                    classes: "govuk-tag--yellow float-right"
+                  })}}
+                {% elseif data.subject1TeachingTeachingStatus == "Accepted" %}
+                  {{ govukTag({
+                    text: "Approved",
+                    classes: "govuk-tag--green float-right"
+                  })}}
+                {% elseif data.subject1TeachingTeachingStatus == "Rejected" %}
+                  {{ govukTag({
+                    text: "Rejected",
+                    classes: "govuk-tag--red float-right"
+                  })}}
+                {% else %}
+                {% endif %}
+              </dd>
+            </div>
+          {% endif %}
         {% endif %}
         <!-- END row for Teaching or lecturing -->
         <!-- START row for Training -->
         {% if data.isTraining == "true" %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
-              Training
-              {% if data.subject1TeachingTrainingStatus == "Action required" %}
-                {{ govukDetails({
-                  summaryText: "Further information required",
-                  html: actionRequiredHtml,
-                  classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
-                }) }} 
-              {% elseif data.subject1TeachingTrainingStatus == "Rejected" %}
-                <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                      Feedback
-                    </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject1TeachingTrainingFeedbackCategory }}</h4>
-                    <p class="govuk-body">{{ data.subject1TeachingTrainingFeedback }}</p>
-                  </div>
-                </details>
-              {% else %}
-            {% endif %}
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {% if data.subject1TeachingTrainingStatus == "Awaiting decision" %}
-                {{ govukTag({
-                  text: "Awaiting decision",
-                  classes: "govuk-tag--purple float-right"
-                })}}
-              {% elseif data.subject1TeachingTrainingStatus == "Action required" %}
-                {{ govukTag({
-                  text: "Action required",
-                  classes: "govuk-tag--yellow float-right"
-                })}}
-              {% elseif data.subject1TeachingTrainingStatus == "Accepted" %}
-                {{ govukTag({
-                  text: "Approved",
-                  classes: "govuk-tag--green float-right"
-                })}}
-              {% elseif data.subject1TeachingTrainingStatus == "Rejected" %}
-                {{ govukTag({
-                  text: "Rejected",
-                  classes: "govuk-tag--red float-right"
-                })}}
-              {% else %}
+          {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject1TeachingTrainingStatus == "Rejected" %}
+          {% else %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
+                Training
+                {% if data.subject1TeachingTrainingStatus == "Action required" %}
+                  {{ govukDetails({
+                    summaryText: "Further information required",
+                    html: actionRequiredHtml,
+                    classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
+                  }) }} 
+                {% elseif data.subject1TeachingTrainingStatus == "Rejected" %}
+                  <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        Feedback
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject1TeachingTrainingFeedbackCategory }}</h4>
+                      <p class="govuk-body">{{ data.subject1TeachingTrainingFeedback }}</p>
+                    </div>
+                  </details>
+                {% else %}
               {% endif %}
-            </dd>
-          </div>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {% if data.subject1TeachingTrainingStatus == "Awaiting decision" %}
+                  {{ govukTag({
+                    text: "Awaiting decision",
+                    classes: "govuk-tag--purple float-right"
+                  })}}
+                {% elseif data.subject1TeachingTrainingStatus == "Action required" %}
+                  {{ govukTag({
+                    text: "Action required",
+                    classes: "govuk-tag--yellow float-right"
+                  })}}
+                {% elseif data.subject1TeachingTrainingStatus == "Accepted" %}
+                  {{ govukTag({
+                    text: "Approved",
+                    classes: "govuk-tag--green float-right"
+                  })}}
+                {% elseif data.subject1TeachingTrainingStatus == "Rejected" %}
+                  {{ govukTag({
+                    text: "Rejected",
+                    classes: "govuk-tag--red float-right"
+                  })}}
+                {% else %}
+                {% endif %}
+              </dd>
+            </div>
+          {% endif %}
         {% endif %}
         <!-- END row for Training -->
         <!-- START row for Educational management -->
         {% if data.isEducationalManagement == "true" %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
-              Educational management
-              {% if data.subject1TeachingEducationalStatus == "Action required" %}
-                {{ govukDetails({
-                  summaryText: "Further information required",
-                  html: actionRequiredHtml,
-                  classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
-                }) }} 
-              {% elseif data.subject1TeachingEducationalStatus == "Rejected" %}
-                <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                      Feedback
-                    </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject1TeachingEducationalFeedbackCategory }}</h4>
-                    <p class="govuk-body">{{ data.subject1TeachingEducationalFeedback }}</p>
-                  </div>
-                </details>
-              {% else %}
-            {% endif %}
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {% if data.subject1TeachingEducationalStatus == "Awaiting decision" %}
-                {{ govukTag({
-                  text: "Awaiting decision",
-                  classes: "govuk-tag--purple float-right"
-                })}}
-              {% elseif data.subject1TeachingEducationalStatus == "Action required" %}
-                {{ govukTag({
-                  text: "Action required",
-                  classes: "govuk-tag--yellow float-right"
-                })}}
-              {% elseif data.subject1TeachingEducationalStatus == "Accepted" %}
-                {{ govukTag({
-                  text: "Approved",
-                  classes: "govuk-tag--green float-right"
-                })}}
-              {% elseif data.subject1TeachingEducationalStatus == "Rejected" %}
-                {{ govukTag({
-                  text: "Rejected",
-                  classes: "govuk-tag--red float-right"
-                })}}
-              {% else %}
+          {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject1TeachingEducationalStatus == "Rejected" %}
+          {% else %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
+                Educational management
+                {% if data.subject1TeachingEducationalStatus == "Action required" %}
+                  {{ govukDetails({
+                    summaryText: "Further information required",
+                    html: actionRequiredHtml,
+                    classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
+                  }) }} 
+                {% elseif data.subject1TeachingEducationalStatus == "Rejected" %}
+                  <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        Feedback
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject1TeachingEducationalFeedbackCategory }}</h4>
+                      <p class="govuk-body">{{ data.subject1TeachingEducationalFeedback }}</p>
+                    </div>
+                  </details>
+                {% else %}
               {% endif %}
-            </dd>
-          </div>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {% if data.subject1TeachingEducationalStatus == "Awaiting decision" %}
+                  {{ govukTag({
+                    text: "Awaiting decision",
+                    classes: "govuk-tag--purple float-right"
+                  })}}
+                {% elseif data.subject1TeachingEducationalStatus == "Action required" %}
+                  {{ govukTag({
+                    text: "Action required",
+                    classes: "govuk-tag--yellow float-right"
+                  })}}
+                {% elseif data.subject1TeachingEducationalStatus == "Accepted" %}
+                  {{ govukTag({
+                    text: "Approved",
+                    classes: "govuk-tag--green float-right"
+                  })}}
+                {% elseif data.subject1TeachingEducationalStatus == "Rejected" %}
+                  {{ govukTag({
+                    text: "Rejected",
+                    classes: "govuk-tag--red float-right"
+                  })}}
+                {% else %}
+                {% endif %}
+              </dd>
+            </div>
+          {% endif %}
         {% endif %}
         <!-- END row for Educational management -->
         <!-- START row for Teacher training -->
         {% if data.isTeacherTraining == "true" %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
-              Teacher training
-              {% if data.subject1TeachingTeacherTrainingStatus == "Action required" %}
-                {{ govukDetails({
-                  summaryText: "Further information required",
-                  html: actionRequiredTTrainingHtml,
-                  classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
-                }) }} 
-              {% elseif data.subject1TeachingTeacherTrainingStatus == "Rejected" %}
-                <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                      Feedback
-                    </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject1TeachingTeacherTrainingFeedbackCategory }}</h4>
-                    <p class="govuk-body">{{ data.subject1TeachingTeacherTrainingFeedback }}</p>
-                  </div>
-                </details>
-              {% else %}
-            {% endif %}
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {% if data.subject1TeachingTeacherTrainingStatus == "Awaiting decision" %}
-                {{ govukTag({
-                  text: "Awaiting decision",
-                  classes: "govuk-tag--purple float-right"
-                })}}
-              {% elseif data.subject1TeachingTeacherTrainingStatus == "Action required" %}
-                {{ govukTag({
-                  text: "Action required",
-                  classes: "govuk-tag--yellow float-right"
-                })}}
-              {% elseif data.subject1TeachingTeacherTrainingStatus == "Accepted" %}
-                {{ govukTag({
-                  text: "Approved",
-                  classes: "govuk-tag--green float-right"
-                })}}
-              {% elseif data.subject1TeachingTeacherTrainingStatus == "Rejected" %}
-                {{ govukTag({
-                  text: "Rejected",
-                  classes: "govuk-tag--red float-right"
-                })}}
-              {% else %}
+          {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject1TeachingTeacherTrainingStatus == "Rejected" %}
+          {% else %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
+                Teacher training
+                {% if data.subject1TeachingTeacherTrainingStatus == "Action required" %}
+                  {{ govukDetails({
+                    summaryText: "Further information required",
+                    html: actionRequiredTTrainingHtml,
+                    classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
+                  }) }} 
+                {% elseif data.subject1TeachingTeacherTrainingStatus == "Rejected" %}
+                  <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        Feedback
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject1TeachingTeacherTrainingFeedbackCategory }}</h4>
+                      <p class="govuk-body">{{ data.subject1TeachingTeacherTrainingFeedback }}</p>
+                    </div>
+                  </details>
+                {% else %}
               {% endif %}
-            </dd>
-          </div>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {% if data.subject1TeachingTeacherTrainingStatus == "Awaiting decision" %}
+                  {{ govukTag({
+                    text: "Awaiting decision",
+                    classes: "govuk-tag--purple float-right"
+                  })}}
+                {% elseif data.subject1TeachingTeacherTrainingStatus == "Action required" %}
+                  {{ govukTag({
+                    text: "Action required",
+                    classes: "govuk-tag--yellow float-right"
+                  })}}
+                {% elseif data.subject1TeachingTeacherTrainingStatus == "Accepted" %}
+                  {{ govukTag({
+                    text: "Approved",
+                    classes: "govuk-tag--green float-right"
+                  })}}
+                {% elseif data.subject1TeachingTeacherTrainingStatus == "Rejected" %}
+                  {{ govukTag({
+                    text: "Rejected",
+                    classes: "govuk-tag--red float-right"
+                  })}}
+                {% else %}
+                {% endif %}
+              </dd>
+            </div>
+          {% endif %}
         {% endif %}
         <!-- END row for Teacher training -->
       </dl>
     </div>
+    {% endif %}
   {% endif %}
 </section>
+{% endif %}
 <!-- END Card for subject 1 -->
 <!-- START Card for subject 2 -->
 {% if data.subject2 == "true" %}
+  {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject2Status == "Rejected" and pageTypeSub != "Application" %}
+  {% else %}
   <section class="x-govuk-summary-card">
     <header class="x-govuk-summary-card__header govuk-!-display-block govuk-!-margin-bottom-2">
       <h2 class="x-govuk-summary-card__title govuk-!-font-size-24">
@@ -568,6 +606,8 @@
     </header>
     <!-- START of assessment -->
     {% if data.isAssessment2 == "true" %}
+      {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject2AssessmentMakingStatus == "Rejected" and data.subject2AssessmentSettingStatus == "Rejected" and data.subject2AssessmentDesigningStatus == "Rejected" and data.subject2AssessmentEvaluatingStatus == "Rejected" %}
+      {% else %}
       <header class="x-govuk-summary-card__header">
         <h2 class="x-govuk-summary-card__title">
           Assessment
@@ -577,282 +617,300 @@
         <dl class="govuk-summary-list">
         <!-- START row for Making assessment judgements -->
         {% if data.isJudgement2 == "true" %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
-              Making assessment judgements
-              {% if data.subject2AssessmentMakingStatus == "Action required" %}
-                {{ govukDetails({
-                  summaryText: "Further information required",
-                  html: actionRequiredHtml,
-                  classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
-                }) }} 
-              {% elseif data.subject2AssessmentMakingStatus == "Rejected" %}
-                <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                      Feedback
-                    </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject2AssessmentMakingFeedbackCategory }}</h4>
-                    <p class="govuk-body">{{ data.subject2AssessmentMakingFeedback }}</p>
-                  </div>
-                </details>
-              {% else %}
-            {% endif %}
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {% if data.subject2AssessmentMakingStatus == "Awaiting decision" %}
-                {{ govukTag({
-                  text: "Awaiting decision",
-                  classes: "govuk-tag--purple float-right"
-                })}}
-              {% elseif data.subject2AssessmentMakingStatus == "Action required" %}
-                {{ govukTag({
-                  text: "Action required",
-                  classes: "govuk-tag--yellow float-right"
-                })}}
-              {% elseif data.subject2AssessmentMakingStatus == "Accepted" %}
-                {{ govukTag({
-                  text: "Approved",
-                  classes: "govuk-tag--green float-right"
-                })}}
-              {% elseif data.subject2AssessmentMakingStatus == "Rejected" %}
-                {{ govukTag({
-                  text: "Rejected",
-                  classes: "govuk-tag--red float-right"
-                })}}
-              {% else %}
+          {% if data.applicationStatus == "Accepted" and data.subject2AssessmentMakingStatus == "Rejected" %}
+          {% else %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
+                Making assessment judgements
+                {% if data.subject2AssessmentMakingStatus == "Action required" %}
+                  {{ govukDetails({
+                    summaryText: "Further information required",
+                    html: actionRequiredHtml,
+                    classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
+                  }) }} 
+                {% elseif data.subject2AssessmentMakingStatus == "Rejected" %}
+                  <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        Feedback
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject2AssessmentMakingFeedbackCategory }}</h4>
+                      <p class="govuk-body">{{ data.subject2AssessmentMakingFeedback }}</p>
+                    </div>
+                  </details>
+                {% else %}
               {% endif %}
-            </dd>
-          </div>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {% if data.subject2AssessmentMakingStatus == "Awaiting decision" %}
+                  {{ govukTag({
+                    text: "Awaiting decision",
+                    classes: "govuk-tag--purple float-right"
+                  })}}
+                {% elseif data.subject2AssessmentMakingStatus == "Action required" %}
+                  {{ govukTag({
+                    text: "Action required",
+                    classes: "govuk-tag--yellow float-right"
+                  })}}
+                {% elseif data.subject2AssessmentMakingStatus == "Accepted" %}
+                  {{ govukTag({
+                    text: "Approved",
+                    classes: "govuk-tag--green float-right"
+                  })}}
+                {% elseif data.subject2AssessmentMakingStatus == "Rejected" %}
+                  {{ govukTag({
+                    text: "Rejected",
+                    classes: "govuk-tag--red float-right"
+                  })}}
+                {% else %}
+                {% endif %}
+              </dd>
+            </div>
+          {% endif %}
         {% endif %}
         <!-- END row for Making assessment judgements -->
         <!-- START row for Standard setting and awarding qualifications -->
         {% if data.isStandardSetting2 == "true" %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
-              Standard setting and awarding qualifications
-              {% if data.subject2AssessmentSettingStatus == "Action required" %}
-                {{ govukDetails({
-                  summaryText: "Further information required",
-                  html: actionRequiredHtml,
-                  classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
-                }) }} 
-              {% elseif data.subject2AssessmentSettingStatus == "Rejected" %}
-                <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                      Feedback
-                    </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject2AssessmentSettingFeedbackCategory }}</h4>
-                    <p class="govuk-body">{{ data.subject2AssessmentSettingFeedback }}</p>
-                  </div>
-                </details>
-              {% else %}
-            {% endif %}
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {% if data.subject2AssessmentSettingStatus == "Awaiting decision" %}
-                {{ govukTag({
-                  text: "Awaiting decision",
-                  classes: "govuk-tag--purple float-right"
-                })}}
-              {% elseif data.subject2AssessmentSettingStatus == "Action required" %}
-                {{ govukTag({
-                  text: "Action required",
-                  classes: "govuk-tag--yellow float-right"
-                })}}
-              {% elseif data.subject2AssessmentSettingStatus == "Accepted" %}
-                {{ govukTag({
-                  text: "Approved",
-                  classes: "govuk-tag--green float-right"
-                })}}
-              {% elseif data.subject2AssessmentSettingStatus == "Rejected" %}
-                {{ govukTag({
-                  text: "Rejected",
-                  classes: "govuk-tag--red float-right"
-                })}}
-              {% else %}
+          {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject2AssessmentSettingStatus == "Rejected" %}
+          {% else %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
+                Standard setting and awarding qualifications
+                {% if data.subject2AssessmentSettingStatus == "Action required" %}
+                  {{ govukDetails({
+                    summaryText: "Further information required",
+                    html: actionRequiredHtml,
+                    classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
+                  }) }} 
+                {% elseif data.subject2AssessmentSettingStatus == "Rejected" %}
+                  <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        Feedback
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject2AssessmentSettingFeedbackCategory }}</h4>
+                      <p class="govuk-body">{{ data.subject2AssessmentSettingFeedback }}</p>
+                    </div>
+                  </details>
+                {% else %}
               {% endif %}
-            </dd>
-          </div>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {% if data.subject2AssessmentSettingStatus == "Awaiting decision" %}
+                  {{ govukTag({
+                    text: "Awaiting decision",
+                    classes: "govuk-tag--purple float-right"
+                  })}}
+                {% elseif data.subject2AssessmentSettingStatus == "Action required" %}
+                  {{ govukTag({
+                    text: "Action required",
+                    classes: "govuk-tag--yellow float-right"
+                  })}}
+                {% elseif data.subject2AssessmentSettingStatus == "Accepted" %}
+                  {{ govukTag({
+                    text: "Approved",
+                    classes: "govuk-tag--green float-right"
+                  })}}
+                {% elseif data.subject2AssessmentSettingStatus == "Rejected" %}
+                  {{ govukTag({
+                    text: "Rejected",
+                    classes: "govuk-tag--red float-right"
+                  })}}
+                {% else %}
+                {% endif %}
+              </dd>
+            </div>
+          {% endif %}
         {% endif %}
         <!-- END row for Standard setting and awarding qualifications -->
         <!-- START row for Designing and developing assessments -->
         {% if data.isDesigning2 == "true" %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
-              Designing and developing assessments
-              {% if data.subject2AssessmentDesigningStatus == "Action required" %}
-                {{ govukDetails({
-                  summaryText: "Further information required",
-                  html: actionRequiredHtml,
-                  classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
-                }) }} 
-              {% elseif data.subject2AssessmentDesigningStatus == "Rejected" %}
-                <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                      Feedback
-                    </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject2AssessmentDesigningFeedbackCategory }}</h4>
-                    <p class="govuk-body">{{ data.subject2AssessmentDesigningFeedback }}</p>
-                  </div>
-                </details>
-              {% else %}
-            {% endif %}
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {% if data.subject2AssessmentDesigningStatus == "Awaiting decision" %}
-                {{ govukTag({
-                  text: "Awaiting decision",
-                  classes: "govuk-tag--purple float-right"
-                })}}
-              {% elseif data.subject2AssessmentDesigningStatus == "Action required" %}
-                {{ govukTag({
-                  text: "Action required",
-                  classes: "govuk-tag--yellow float-right"
-                })}}
-              {% elseif data.subject2AssessmentDesigningStatus == "Accepted" %}
-                {{ govukTag({
-                  text: "Approved",
-                  classes: "govuk-tag--green float-right"
-                })}}
-              {% elseif data.subject2AssessmentDesigningStatus == "Rejected" %}
-                {{ govukTag({
-                  text: "Rejected",
-                  classes: "govuk-tag--red float-right"
-                })}}
-              {% else %}
+          {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject2AssessmentDesigningStatus == "Rejected" %}
+          {% else %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
+                Designing and developing assessments
+                {% if data.subject2AssessmentDesigningStatus == "Action required" %}
+                  {{ govukDetails({
+                    summaryText: "Further information required",
+                    html: actionRequiredHtml,
+                    classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
+                  }) }} 
+                {% elseif data.subject2AssessmentDesigningStatus == "Rejected" %}
+                  <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        Feedback
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject2AssessmentDesigningFeedbackCategory }}</h4>
+                      <p class="govuk-body">{{ data.subject2AssessmentDesigningFeedback }}</p>
+                    </div>
+                  </details>
+                {% else %}
               {% endif %}
-            </dd>
-          </div>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {% if data.subject2AssessmentDesigningStatus == "Awaiting decision" %}
+                  {{ govukTag({
+                    text: "Awaiting decision",
+                    classes: "govuk-tag--purple float-right"
+                  })}}
+                {% elseif data.subject2AssessmentDesigningStatus == "Action required" %}
+                  {{ govukTag({
+                    text: "Action required",
+                    classes: "govuk-tag--yellow float-right"
+                  })}}
+                {% elseif data.subject2AssessmentDesigningStatus == "Accepted" %}
+                  {{ govukTag({
+                    text: "Approved",
+                    classes: "govuk-tag--green float-right"
+                  })}}
+                {% elseif data.subject2AssessmentDesigningStatus == "Rejected" %}
+                  {{ govukTag({
+                    text: "Rejected",
+                    classes: "govuk-tag--red float-right"
+                  })}}
+                {% else %}
+                {% endif %}
+              </dd>
+            </div>
+          {% endif %}
         {% endif %}
         <!-- END row for Designing and developing assessments -->
         <!-- START row for Evaluating assessments or assessment approaches -->
         {% if data.isEvaluating2 == "true" %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
-              Evaluating assessments or assessment approaches
-              {% if data.subject2AssessmentEvaluatingStatus == "Action required" %}
-                {{ govukDetails({
-                  summaryText: "Further information required",
-                  html: actionRequiredHtml,
-                  classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
-                }) }} 
-              {% elseif data.subject2AssessmentEvaluatingStatus == "Rejected" %}
-                <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                      Feedback
-                    </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject2AssessmentEvaluatingFeedbackCategory }}</h4>
-                    <p class="govuk-body">{{ data.subject2AssessmentEvaluatingFeedback }}</p>
-                  </div>
-                </details>
-              {% else %}
-            {% endif %}
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {% if data.subject2AssessmentEvaluatingStatus == "Awaiting decision" %}
-                {{ govukTag({
-                  text: "Awaiting decision",
-                  classes: "govuk-tag--purple float-right"
-                })}}
-              {% elseif data.subject2AssessmentEvaluatingStatus == "Action required" %}
-                {{ govukTag({
-                  text: "Action required",
-                  classes: "govuk-tag--yellow float-right"
-                })}}
-              {% elseif data.subject2AssessmentEvaluatingStatus == "Accepted" %}
-                {{ govukTag({
-                  text: "Approved",
-                  classes: "govuk-tag--green float-right"
-                })}}
-              {% elseif data.subject2AssessmentEvaluatingStatus == "Rejected" %}
-                {{ govukTag({
-                  text: "Rejected",
-                  classes: "govuk-tag--red float-right"
-                })}}
-              {% else %}
+          {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject2AssessmentEvaluatingStatus == "Rejected" %}
+          {% else %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
+                Evaluating assessments or assessment approaches
+                {% if data.subject2AssessmentEvaluatingStatus == "Action required" %}
+                  {{ govukDetails({
+                    summaryText: "Further information required",
+                    html: actionRequiredHtml,
+                    classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
+                  }) }} 
+                {% elseif data.subject2AssessmentEvaluatingStatus == "Rejected" %}
+                  <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        Feedback
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject2AssessmentEvaluatingFeedbackCategory }}</h4>
+                      <p class="govuk-body">{{ data.subject2AssessmentEvaluatingFeedback }}</p>
+                    </div>
+                  </details>
+                {% else %}
               {% endif %}
-            </dd>
-          </div>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {% if data.subject2AssessmentEvaluatingStatus == "Awaiting decision" %}
+                  {{ govukTag({
+                    text: "Awaiting decision",
+                    classes: "govuk-tag--purple float-right"
+                  })}}
+                {% elseif data.subject2AssessmentEvaluatingStatus == "Action required" %}
+                  {{ govukTag({
+                    text: "Action required",
+                    classes: "govuk-tag--yellow float-right"
+                  })}}
+                {% elseif data.subject2AssessmentEvaluatingStatus == "Accepted" %}
+                  {{ govukTag({
+                    text: "Approved",
+                    classes: "govuk-tag--green float-right"
+                  })}}
+                {% elseif data.subject2AssessmentEvaluatingStatus == "Rejected" %}
+                  {{ govukTag({
+                    text: "Rejected",
+                    classes: "govuk-tag--red float-right"
+                  })}}
+                {% else %}
+                {% endif %}
+              </dd>
+            </div>
+          {% endif %}
         {% endif %}
         <!-- END row for Evaluating assessments or assessment approaches -->
       </dl>
     </div>
+    {% endif %}
   {% endif %}
   <!-- START of Industry, occupational or professional -->
     {% if data.isIndustry2 == "true" %}
-      <header class="x-govuk-summary-card__header">
-        <h2 class="x-govuk-summary-card__title">
-          Industry, occupational or professional
-        </h2>
-      </header>
-      <div class="x-govuk-summary-card__body">
-        <dl class="govuk-summary-list">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular  govuk-!-padding-bottom-0 govuk-!-width-three-quarters">
-              Industry, occupational or professional
-              {% if data.subject2IndustryStatus == "Action required" %}
-                {{ govukDetails({
-                  summaryText: "Further information required",
-                  html: actionRequiredHtml,
-                  classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
-                }) }} 
-              {% elseif data.subject2IndustryStatus == "Rejected" %}
-                <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                      Feedback
-                    </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject2IndustryFeedbackCategory }}</h4>
-                    <p class="govuk-body">{{ data.subject2IndustryFeedback }}</p>
-                  </div>
-                </details>
-              {% else %}
-            {% endif %}
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {% if data.subject2IndustryStatus == "Awaiting decision" %}
-                {{ govukTag({
-                  text: "Awaiting decision",
-                  classes: "govuk-tag--purple float-right"
-                })}}
-              {% elseif data.subject2IndustryStatus == "Action required" %}
-                {{ govukTag({
-                  text: "Action required",
-                  classes: "govuk-tag--yellow float-right"
-                })}}
-              {% elseif data.subject2IndustryStatus == "Accepted" %}
-                {{ govukTag({
-                  text: "Approved",
-                  classes: "govuk-tag--green float-right"
-                })}}
-              {% elseif data.subject2IndustryStatus == "Rejected" %}
-                {{ govukTag({
-                  text: "Rejected",
-                  classes: "govuk-tag--red float-right"
-                })}}
-              {% else %}
+      {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject2IndustryStatus == "Rejected" %}
+      {% else %}
+        <header class="x-govuk-summary-card__header">
+          <h2 class="x-govuk-summary-card__title">
+            Industry, occupational or professional
+          </h2>
+        </header>
+        <div class="x-govuk-summary-card__body">
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular  govuk-!-padding-bottom-0 govuk-!-width-three-quarters">
+                Industry, occupational or professional
+                {% if data.subject2IndustryStatus == "Action required" %}
+                  {{ govukDetails({
+                    summaryText: "Further information required",
+                    html: actionRequiredHtml,
+                    classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
+                  }) }} 
+                {% elseif data.subject2IndustryStatus == "Rejected" %}
+                  <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        Feedback
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject2IndustryFeedbackCategory }}</h4>
+                      <p class="govuk-body">{{ data.subject2IndustryFeedback }}</p>
+                    </div>
+                  </details>
+                {% else %}
               {% endif %}
-            </dd>
-          </div>
-      </dl>
-    </div>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {% if data.subject2IndustryStatus == "Awaiting decision" %}
+                  {{ govukTag({
+                    text: "Awaiting decision",
+                    classes: "govuk-tag--purple float-right"
+                  })}}
+                {% elseif data.subject2IndustryStatus == "Action required" %}
+                  {{ govukTag({
+                    text: "Action required",
+                    classes: "govuk-tag--yellow float-right"
+                  })}}
+                {% elseif data.subject2IndustryStatus == "Accepted" %}
+                  {{ govukTag({
+                    text: "Approved",
+                    classes: "govuk-tag--green float-right"
+                  })}}
+                {% elseif data.subject2IndustryStatus == "Rejected" %}
+                  {{ govukTag({
+                    text: "Rejected",
+                    classes: "govuk-tag--red float-right"
+                  })}}
+                {% else %}
+                {% endif %}
+              </dd>
+            </div>
+        </dl>
+      </div>
+    {% endif %}
   {% endif %}
   <!-- START of Teaching, lecturing or training -->
     {% if data.isTeaching2 == "true" %}
+      {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject2TeachingTeachingStatus == "Rejected" and data.subject2TeachingTrainingStatus == "Rejected" and data.subject2TeachingEducationalStatus == "Rejected" and data.subject2TeachingTeacherTrainingStatus == "Rejected" %}
+      {% else %}
       <header class="x-govuk-summary-card__header">
         <h2 class="x-govuk-summary-card__title">
           Teaching, lecturing or training
@@ -862,218 +920,232 @@
         <dl class="govuk-summary-list">
         <!-- START row for Teaching or lecturing -->
         {% if data.isLecturing2 == "true" %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
-              Teaching or lecturing
-              {% if data.subject2TeachingTeachingStatus == "Action required" %}
-                {{ govukDetails({
-                  summaryText: "Further information required",
-                  html: actionRequiredHtml,
-                  classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
-                }) }} 
-              {% elseif data.subject2TeachingTeachingStatus == "Rejected" %}
-                <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                      Feedback
-                    </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject2TeachingTeachingFeedbackCategory }}</h4>
-                    <p class="govuk-body">{{ data.subject2TeachingTeachingFeedback }}</p>
-                  </div>
-                </details>
-              {% else %}
-            {% endif %}
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {% if data.subject2TeachingTeachingStatus == "Awaiting decision" %}
-                {{ govukTag({
-                  text: "Awaiting decision",
-                  classes: "govuk-tag--purple float-right"
-                })}}
-              {% elseif data.subject2TeachingTeachingStatus == "Action required" %}
-                {{ govukTag({
-                  text: "Action required",
-                  classes: "govuk-tag--yellow float-right"
-                })}}
-              {% elseif data.subject2TeachingTeachingStatus == "Accepted" %}
-                {{ govukTag({
-                  text: "Approved",
-                  classes: "govuk-tag--green float-right"
-                })}}
-              {% elseif data.subject2TeachingTeachingStatus == "Rejected" %}
-                {{ govukTag({
-                  text: "Rejected",
-                  classes: "govuk-tag--red float-right"
-                })}}
-              {% else %}
+          {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject2TeachingTeachingStatus == "Rejected" %}
+          {% else %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
+                Teaching or lecturing
+                {% if data.subject2TeachingTeachingStatus == "Action required" %}
+                  {{ govukDetails({
+                    summaryText: "Further information required",
+                    html: actionRequiredHtml,
+                    classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
+                  }) }} 
+                {% elseif data.subject2TeachingTeachingStatus == "Rejected" %}
+                  <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        Feedback
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject2TeachingTeachingFeedbackCategory }}</h4>
+                      <p class="govuk-body">{{ data.subject2TeachingTeachingFeedback }}</p>
+                    </div>
+                  </details>
+                {% else %}
               {% endif %}
-            </dd>
-          </div>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {% if data.subject2TeachingTeachingStatus == "Awaiting decision" %}
+                  {{ govukTag({
+                    text: "Awaiting decision",
+                    classes: "govuk-tag--purple float-right"
+                  })}}
+                {% elseif data.subject2TeachingTeachingStatus == "Action required" %}
+                  {{ govukTag({
+                    text: "Action required",
+                    classes: "govuk-tag--yellow float-right"
+                  })}}
+                {% elseif data.subject2TeachingTeachingStatus == "Accepted" %}
+                  {{ govukTag({
+                    text: "Approved",
+                    classes: "govuk-tag--green float-right"
+                  })}}
+                {% elseif data.subject2TeachingTeachingStatus == "Rejected" %}
+                  {{ govukTag({
+                    text: "Rejected",
+                    classes: "govuk-tag--red float-right"
+                  })}}
+                {% else %}
+                {% endif %}
+              </dd>
+            </div>
+          {% endif %}
         {% endif %}
         <!-- END row for Teaching or lecturing -->
         <!-- START row for Training -->
         {% if data.isTraining2 == "true" %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
-              Training
-              {% if data.subject2TeachingTrainingStatus == "Action required" %}
-                {{ govukDetails({
-                  summaryText: "Further information required",
-                  html: actionRequiredHtml,
-                  classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
-                }) }} 
-              {% elseif data.subject2TeachingTrainingStatus == "Rejected" %}
-                <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                      Feedback
-                    </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject2TeachingTrainingFeedbackCategory }}</h4>
-                    <p class="govuk-body">{{ data.subject2TeachingTrainingFeedback }}</p>
-                  </div>
-                </details>
-              {% else %}
-            {% endif %}
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {% if data.subject2TeachingTrainingStatus == "Awaiting decision" %}
-                {{ govukTag({
-                  text: "Awaiting decision",
-                  classes: "govuk-tag--purple float-right"
-                })}}
-              {% elseif data.subject2TeachingTrainingStatus == "Action required" %}
-                {{ govukTag({
-                  text: "Action required",
-                  classes: "govuk-tag--yellow float-right"
-                })}} 
-              {% elseif data.subject2TeachingTrainingStatus == "Accepted" %}
-                {{ govukTag({
-                  text: "Approved",
-                  classes: "govuk-tag--green float-right"
-                })}}
-              {% elseif data.subject2TeachingTrainingStatus == "Rejected" %}
-                {{ govukTag({
-                  text: "Rejected",
-                  classes: "govuk-tag--red float-right"
-                })}}
-              {% else %}
+          {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject2TeachingTrainingStatus == "Rejected" %}
+          {% else %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
+                Training
+                {% if data.subject2TeachingTrainingStatus == "Action required" %}
+                  {{ govukDetails({
+                    summaryText: "Further information required",
+                    html: actionRequiredHtml,
+                    classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
+                  }) }} 
+                {% elseif data.subject2TeachingTrainingStatus == "Rejected" %}
+                  <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        Feedback
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject2TeachingTrainingFeedbackCategory }}</h4>
+                      <p class="govuk-body">{{ data.subject2TeachingTrainingFeedback }}</p>
+                    </div>
+                  </details>
+                {% else %}
               {% endif %}
-            </dd>
-          </div>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {% if data.subject2TeachingTrainingStatus == "Awaiting decision" %}
+                  {{ govukTag({
+                    text: "Awaiting decision",
+                    classes: "govuk-tag--purple float-right"
+                  })}}
+                {% elseif data.subject2TeachingTrainingStatus == "Action required" %}
+                  {{ govukTag({
+                    text: "Action required",
+                    classes: "govuk-tag--yellow float-right"
+                  })}} 
+                {% elseif data.subject2TeachingTrainingStatus == "Accepted" %}
+                  {{ govukTag({
+                    text: "Approved",
+                    classes: "govuk-tag--green float-right"
+                  })}}
+                {% elseif data.subject2TeachingTrainingStatus == "Rejected" %}
+                  {{ govukTag({
+                    text: "Rejected",
+                    classes: "govuk-tag--red float-right"
+                  })}}
+                {% else %}
+                {% endif %}
+              </dd>
+            </div>
+          {% endif %}
         {% endif %}
         <!-- END row for Training -->
         <!-- START row for Educational management -->
         {% if data.isEducationalManagement2 == "true" %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
-              Educational management
-              {% if data.subject2TeachingEducationalStatus == "Action required" %}
-                {{ govukDetails({
-                  summaryText: "Further information required",
-                  html: actionRequiredHtml,
-                  classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
-                }) }} 
-              {% elseif data.subject2TeachingEducationalStatus == "Rejected" %}
-                <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                      Feedback
-                    </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject2TeachingEducationalFeedbackCategory }}</h4>
-                    <p class="govuk-body">{{ data.subject2TeachingEducationalFeedback }}</p>
-                  </div>
-                </details>
-              {% else %}
-            {% endif %}
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {% if data.subject2TeachingEducationalStatus == "Awaiting decision" %}
-                {{ govukTag({
-                  text: "Awaiting decision",
-                  classes: "govuk-tag--purple float-right"
-                })}}
-              {% elseif data.subject2TeachingEducationalStatus == "Action required" %}
-                {{ govukTag({
-                  text: "Action required",
-                  classes: "govuk-tag--yellow float-right"
-                })}}
-              {% elseif data.subject2TeachingEducationalStatus == "Accepted" %}
-                {{ govukTag({
-                  text: "Approved",
-                  classes: "govuk-tag--green float-right"
-                })}}
-              {% elseif data.subject2TeachingEducationalStatus == "Rejected" %}
-                {{ govukTag({
-                  text: "Rejected",
-                  classes: "govuk-tag--red float-right"
-                })}}
-              {% else %}
+          {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject2TeachingEducationalStatus == "Rejected" %}
+          {% else %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
+                Educational management
+                {% if data.subject2TeachingEducationalStatus == "Action required" %}
+                  {{ govukDetails({
+                    summaryText: "Further information required",
+                    html: actionRequiredHtml,
+                    classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
+                  }) }} 
+                {% elseif data.subject2TeachingEducationalStatus == "Rejected" %}
+                  <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        Feedback
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject2TeachingEducationalFeedbackCategory }}</h4>
+                      <p class="govuk-body">{{ data.subject2TeachingEducationalFeedback }}</p>
+                    </div>
+                  </details>
+                {% else %}
               {% endif %}
-            </dd>
-          </div>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {% if data.subject2TeachingEducationalStatus == "Awaiting decision" %}
+                  {{ govukTag({
+                    text: "Awaiting decision",
+                    classes: "govuk-tag--purple float-right"
+                  })}}
+                {% elseif data.subject2TeachingEducationalStatus == "Action required" %}
+                  {{ govukTag({
+                    text: "Action required",
+                    classes: "govuk-tag--yellow float-right"
+                  })}}
+                {% elseif data.subject2TeachingEducationalStatus == "Accepted" %}
+                  {{ govukTag({
+                    text: "Approved",
+                    classes: "govuk-tag--green float-right"
+                  })}}
+                {% elseif data.subject2TeachingEducationalStatus == "Rejected" %}
+                  {{ govukTag({
+                    text: "Rejected",
+                    classes: "govuk-tag--red float-right"
+                  })}}
+                {% else %}
+                {% endif %}
+              </dd>
+            </div>
+          {% endif %}
         {% endif %}
         <!-- END row for Educational management -->
         <!-- START row for Teacher training -->
         {% if data.isTeacherTraining2 == "true" %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
-              Teacher training
-              {% if data.subject2TeachingTeacherTrainingStatus == "Action required" %}
-                {{ govukDetails({
-                  summaryText: "Further information required",
-                  html: actionRequiredTTrainingHtml,
-                  classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
-                }) }} 
-              {% elseif data.subject2TeachingTeacherTrainingStatus == "Rejected" %}
-                <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                      Feedback
-                    </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject2TeachingTeacherTrainingFeedbackCategory }}</h4>
-                    <p class="govuk-body">{{ data.subject2TeachingTeacherTrainingFeedback }}</p>
-                  </div>
-                </details>
-              {% else %}
-            {% endif %}
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {% if data.subject2TeachingTeacherTrainingStatus == "Awaiting decision" %}
-                {{ govukTag({
-                  text: "Awaiting decision",
-                  classes: "govuk-tag--purple float-right"
-                })}}
-              {% elseif data.subject2TeachingTeacherTrainingStatus == "Action required" %}
-                {{ govukTag({
-                  text: "Action required",
-                  classes: "govuk-tag--yellow float-right"
-                })}}
-              {% elseif data.subject2TeachingTeacherTrainingStatus == "Accepted" %}
-                {{ govukTag({
-                  text: "Approved",
-                  classes: "govuk-tag--green float-right"
-                })}}
-              {% elseif data.subject2TeachingTeacherTrainingStatus == "Rejected" %}
-                {{ govukTag({
-                  text: "Rejected",
-                  classes: "govuk-tag--red float-right"
-                })}}
-              {% else %}
+          {% if data.applicationStatus == "Accepted" and pageTypeSub != "Application" and data.subject2TeachingTeacherTrainingStatus == "Rejected" %}
+          {% else %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key vertical-align govuk-!-font-weight-regular govuk-!-width-three-quarters">
+                Teacher training
+                {% if data.subject2TeachingTeacherTrainingStatus == "Action required" %}
+                  {{ govukDetails({
+                    summaryText: "Further information required",
+                    html: actionRequiredTTrainingHtml,
+                    classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-1"
+                  }) }} 
+                {% elseif data.subject2TeachingTeacherTrainingStatus == "Rejected" %}
+                  <details class="govuk-details govuk-!-margin-top-2 govuk-!-margin-bottom-1" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        Feedback
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      <h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-1">{{ data.subject2TeachingTeacherTrainingFeedbackCategory }}</h4>
+                      <p class="govuk-body">{{ data.subject2TeachingTeacherTrainingFeedback }}</p>
+                    </div>
+                  </details>
+                {% else %}
               {% endif %}
-            </dd>
-          </div>
-        {% endif %}
-        <!-- END row for Teacher training -->
-      </dl>
-    </div>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {% if data.subject2TeachingTeacherTrainingStatus == "Awaiting decision" %}
+                  {{ govukTag({
+                    text: "Awaiting decision",
+                    classes: "govuk-tag--purple float-right"
+                  })}}
+                {% elseif data.subject2TeachingTeacherTrainingStatus == "Action required" %}
+                  {{ govukTag({
+                    text: "Action required",
+                    classes: "govuk-tag--yellow float-right"
+                  })}}
+                {% elseif data.subject2TeachingTeacherTrainingStatus == "Accepted" %}
+                  {{ govukTag({
+                    text: "Approved",
+                    classes: "govuk-tag--green float-right"
+                  })}}
+                {% elseif data.subject2TeachingTeacherTrainingStatus == "Rejected" %}
+                  {{ govukTag({
+                    text: "Rejected",
+                    classes: "govuk-tag--red float-right"
+                  })}}
+                {% else %}
+                {% endif %}
+              </dd>
+            </div>
+          {% endif %}
+          <!-- END row for Teacher training -->
+        </dl>
+      </div>
+    {% endif %}
+    {% endif %}
   {% endif %}
   {% endif %}
 </section>
+{% endif %}

--- a/app/views/_includes/summary-cards/subjects.html
+++ b/app/views/_includes/summary-cards/subjects.html
@@ -171,8 +171,12 @@
   </ul>
 {% endset %}
 
-{% if data.applicationStatus != "incomplete" %}
-  <p class="govuk-body govuk-!-margin-top-0"><a href="/account/your-details/subjects">See the status of your application by subject or occupational area </a></p>
+{% if pageType == "Account" %}
+  {% if (data.applicationStatus == "Accepted") %}
+    {% elseif (data.applicationStatus == "Rejected") %}
+    {% else %}
+    <p class="govuk-body govuk-!-margin-top-0"><a href="/account/your-details/subjects">See the status of your application by subject or occupational area </a></p>
+  {% endif %}
 {% endif %}
 
 {# If assessment only expertise, display the answers to additional questions #}

--- a/app/views/account/index.html
+++ b/app/views/account/index.html
@@ -60,7 +60,11 @@
                 <div class="eyfs-card--clickable">
                   <div class="eyfs-card__content">
                     <h3 class="govuk-heading-m govuk-!-margin-top-0 govuk-!-margin-bottom-0">View your subject or occupational areas </h3>
-                    <p class="govuk-body-s govuk-!-margin-top-2 govuk-!-margin-bottom-0">See the status of your application for each subject or occupational area you applied for. </p>
+                    {% if data.applicationStatus == "Accepted" %}
+                      <p class="govuk-body-s govuk-!-margin-top-2 govuk-!-margin-bottom-0">See a list of the subject or occupational areas you are approved for. </p>
+                      {% else %}
+                      <p class="govuk-body-s govuk-!-margin-top-2 govuk-!-margin-bottom-0">See the status of your application for each subject or occupational areas you applied for. </p>
+                    {% endif %}
                   </div>
                 </div>
               </a>
@@ -70,7 +74,7 @@
                 <div class="eyfs-card--clickable">
                   <div class="eyfs-card__content">
                     <h3 class="govuk-heading-m govuk-!-margin-top-0 govuk-!-margin-bottom-0">Read or reply to messages </h3>
-                    <p class="govuk-body-s govuk-!-margin-top-2 govuk-!-margin-bottom-0">If any futher details are needed to proceed with your application we will send a message. </p>
+                    <p class="govuk-body-s govuk-!-margin-top-2 govuk-!-margin-bottom-0">View any messages Ofqual have sent you, view your replies or send a reply. </p>
                   </div>
                 </div>
               </a>

--- a/app/views/account/your-details/application.html
+++ b/app/views/account/your-details/application.html
@@ -61,6 +61,13 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <h1 class="govuk-heading-l">{{ subHeading }}</h1>
       {% include "_includes/summary-cards/application-status.html" %}
+      {% if data.applicationStatus == "Accepted" %}
+        <section class="govuk-!-margin-bottom-8">
+          <h2 id="subject-status" class="govuk-heading-m govuk-!-font-size-27">Status by subject or occupational area</h2>
+          {% include "_includes/summary-cards/subject-status.html" %}
+        </section>
+      {% endif %}
+
       {# Include all the application sections #}
       {% include "_includes/shared/application-sections.html" %}
     <div>

--- a/app/views/account/your-details/subjects.html
+++ b/app/views/account/your-details/subjects.html
@@ -38,8 +38,13 @@
     </div>
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <h1 class="govuk-heading-l">{{ subHeading }}</h1>
-      <p>Here you can view all the subjects and specialisms you applied for and the outcome of your application for each. </p>
-      <p><a class="govuk-link" href="/account/your-details/application">View full application</a></p>
+      {% if data.applicationStatus == "Accepted" %}
+        <p>Here is a list of the subjects and occupational areas you have been approved for. </p>
+        <p>To see the subject or occupational areas you have applied for, which were not approved <a class="govuk-link" href="/account/your-details/application">view your application</a>.</p>
+        {% else %}
+          <p>Here you can view all the subjects and occupational areas you applied for and status of your application for each. </p>
+          <p><a class="govuk-link" href="/account/your-details/application">View full application</a></p>
+      {% endif %}
       <section class="govuk-!-margin-bottom-8">
         {% include "_includes/summary-cards/subject-status.html" %}
       </section>


### PR DESCRIPTION
**Changes made** 

Updates for approved applications to reflect that this is now the users account and application becomes more irrelevant over time:
- show renewal date
- show date approved
- don’t show date submitted or last updated
- change ‘subject status’ phrasing to be more like ‘View your subject or occupational areas'.
- Change ‘application’ to ‘account’

For all accounts with an application outcome:
- The subjects page only show approved subject specialisms. 
- The outcome for all of the applied for subjects is shown on the Application page. 
- Made text on subjects page relevant to account status 
- Made text in the boxes on the Home page relevant to account status 

- Also added Subject 2 to all statuses.