### PR TITLE
subject further evidence as a form

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -1671,8 +1671,8 @@ module.exports = {
   "oneLoginEmail": "name@email.com",
   // set account messages status
   "proofNameChangeReply": "noReply",
-  "subjectEvidenceReply": "noReply",
-  "teachingEvidenceReply": "noReply",
+  "makingAssessmentsEvidenceSent": "",
+  "ttrainingEvidenceSent": "",
   "messageSent": "none",
   "applicationStatus": "incomplete",
   "accountMessageSubject": "",

--- a/app/views/_includes/shared/application-sections.html
+++ b/app/views/_includes/shared/application-sections.html
@@ -128,25 +128,25 @@
             {% endif %}
           {% endfor %}
           {% if data.communicationCompleted == "complete" %}
-          <h2 class="govuk-heading-m">Communication and analytical judgement skills</h2>
-          {% include "_includes/summary-cards/communication-analytical-judgement-skills.html" %}
-        {% else %}
-          {{ appInsetText({
-            sectionName: "Communication and analytical judgement skills",
-            sectionHref: "./communication-analytical-judgement-skills",
-            classes: "app-inset-text--error" if data.showErrors == "true"
-          })}}
-        {% endif %} 
-        {% if data.furtherEvidenceDetails == "complete" %}
-          <h2 class="govuk-heading-m">Further supporting evidence</h2>
-          {% include "_includes/summary-cards/further-evidence.html" %}
-        {% else %}
-          {{ appInsetText({
-            sectionName: "Further supporting evidence",
-            sectionHref: "./further-evidence",
-            classes: "app-inset-text--error" if data.showErrors == "true"
-          })}}
-        {% endif %} 
+            <h2 class="govuk-heading-m">Communication and analytical judgement skills</h2>
+            {% include "_includes/summary-cards/communication-analytical-judgement-skills.html" %}
+            {% else %}
+              {{ appInsetText({
+                sectionName: "Communication and analytical judgement skills",
+                sectionHref: "./communication-analytical-judgement-skills",
+                classes: "app-inset-text--error" if data.showErrors == "true"
+              })}}
+          {% endif %} 
+          {% if data.furtherEvidenceDetails == "complete" %}
+            <h2 class="govuk-heading-m">Further supporting evidence</h2>
+            {% include "_includes/summary-cards/further-evidence.html" %}
+            {% else %}
+              {{ appInsetText({
+                sectionName: "Further supporting evidence",
+                sectionHref: "./further-evidence",
+                classes: "app-inset-text--error" if data.showErrors == "true"
+              })}}
+          {% endif %}
         {% endif %}
       </section>
       

--- a/app/views/_includes/summary-cards/application-status.html
+++ b/app/views/_includes/summary-cards/application-status.html
@@ -35,15 +35,15 @@
   {% endset %}
   
   {% set actionRequiredHtml %}
-    {% if data.subjectEvidenceReply == "replied" %}
-      <p class="govuk-body-s govuk-!-margin-bottom-1">You replied <time datetime="">{{ "" | today |  govukDate }}</time></p>
+    {% if data.makingAssessmentsEvidenceSent == "sent" %}
+      <p class="govuk-body-s govuk-!-margin-bottom-1">You sent evidence <time datetime="">{{ "" | today |  govukDate }}</time></p>
       {% else %}
         <p class="govuk-body-s govuk-!-margin-bottom-1 "><time datetime="">{{ "" | yesterday |  govukDate }}</time></p>
     {% endif %}
     <h4 class="govuk-!-margin-top-1 govuk-!-margin-bottom-1">{{ data.applicationAction }}</h4>
     <p><a href="{{ data.applicationActionLink }}">View message</a></p>
-    {% if data.teachingEvidenceReply == "replied" %}
-      <p class="govuk-body-s govuk-!-margin-bottom-1">You replied <time datetime="">{{ "" | today |  govukDate }}</time></p>
+    {% if data.ttrainingEvidenceSent == "sent" %}
+      <p class="govuk-body-s govuk-!-margin-bottom-1">You sent evidence <time datetime="">{{ "" | today |  govukDate }}</time></p>
       {% else %}
         <p class="govuk-body-s govuk-!-margin-bottom-1 "><time datetime="">{{ "" | yesterday |  govukDate }}</time></p>
     {% endif %}

--- a/app/views/_includes/summary-cards/further-evidence-making-assessment-judgements.html
+++ b/app/views/_includes/summary-cards/further-evidence-making-assessment-judgements.html
@@ -1,0 +1,20 @@
+
+{{ xGovukSummaryCard({
+  rows: [
+  {
+    key: {
+      text: "Provide further evidence of your experience in making assessment judgements"
+    },
+    value: {
+      text: data.assessmentJudgementDetailsFurtherEvidence
+    },
+    actions: {
+      items: [{
+        text: "Change ",
+        visuallyHiddenText: "Provide further evidence of your experience in teacher training",
+        href: "/account/your-details/application/further-evidence-making-assessment-judgements"
+      }]
+    } if pageTypeSub != "Application"
+  }
+  ]
+}) }}

--- a/app/views/_includes/summary-cards/further-evidence-teacher-training.html
+++ b/app/views/_includes/summary-cards/further-evidence-teacher-training.html
@@ -1,0 +1,20 @@
+
+{{ xGovukSummaryCard({
+  rows: [
+  {
+    key: {
+      text: "Provide further evidence of your experience in teacher training"
+    },
+    value: {
+      text: data.teachingTeacherTrainingDetailsFurtherEvidence
+    },
+    actions: {
+      items: [{
+        text: "Change ",
+        visuallyHiddenText: "Provide further evidence of your experience in teacher training",
+        href: "/account/your-details/application/further-evidence-teacher-training"
+      }]
+    } if pageTypeSub != "Application"
+  }
+  ]
+}) }}

--- a/app/views/_includes/summary-cards/further-evidence.html
+++ b/app/views/_includes/summary-cards/further-evidence.html
@@ -1,6 +1,7 @@
+{% if pageType != "Account" %}
   {{ xGovukSummaryCard({
-    
-    rows: [{
+    rows: [
+    {
       key: {
         text: "Provide details of any further supporting evidence"
       },
@@ -13,6 +14,37 @@
           visuallyHiddenText: "provide details of any further supporting evidence",
           href: "/application/further-evidence"
         }]
-      } if pageType != "Account"
-    }]
+      }
+    }
+    ]
   }) }}
+  {% else %}
+    {{ xGovukSummaryCard({
+      rows: [
+      {
+        key: {
+          text: "Provide details of any further supporting evidence"
+        },
+        value: {
+          text: data.furtherEvidenceSummary or "Not provided"
+        }
+      } if pageTypeSub != "FurtherEvidence",
+      {
+        key: {
+          text: "Provide further evidence of your experience in making assessment judgements"
+        },
+        value: {
+          text: data.assessmentJudgementDetailsFurtherEvidence
+        }
+      } if data.makingAssessmentsEvidenceSent == "sent",
+      {
+        key: {
+          text: "Provide further evidence of your experience in teacher training"
+        },
+        value: {
+          text: data.teachingTeacherTrainingDetailsFurtherEvidence
+        }
+      } if data.ttrainingEvidenceSent == "sent"
+      ]
+    }) }}
+  {% endif %}

--- a/app/views/_includes/summary-cards/subject-status.html
+++ b/app/views/_includes/summary-cards/subject-status.html
@@ -1,5 +1,5 @@
   {% set actionRequiredHtml %}
-    {% if data.subjectEvidenceReply == "replied" %}
+    {% if data.makingAssessmentsEvidenceSent == "sent" %}
       <p class="govuk-body-s govuk-!-margin-bottom-1">You replied <time datetime="">{{ "" | today |  govukDate }}</time></p>
     {% else %}
       <p class="govuk-body-s govuk-!-margin-bottom-1 "><time datetime="">{{ "" | yesterday |  govukDate }}</time></p>
@@ -19,7 +19,7 @@
   {% endset %}
 
   {% set actionRequiredTTrainingHtml %}
-    {% if data.teachingEvidenceReply == "replied" %}
+    {% if data.ttrainingEvidenceSent == "replied" %}
       <p class="govuk-body-s govuk-!-margin-bottom-1">You replied <time datetime="">{{ "" | today |  govukDate }}</time></p>
     {% else %}
       <p class="govuk-body-s govuk-!-margin-bottom-1 "><time datetime="">{{ "" | yesterday |  govukDate }}</time></p>

--- a/app/views/account/messages/further-evidence-required-ttraining.html
+++ b/app/views/account/messages/further-evidence-required-ttraining.html
@@ -8,44 +8,27 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <span class="govuk-caption-l">24 Feb 2023 </span>
+      <span class="govuk-caption-l">{{ "" | yesterday |  govukDate }} </span>
       <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-      <p class="govuk-body">To proceed with your application we need more evidence of your experience in: </p>
-      <h2 class="govuk-heading-m"><span class="govuk-!-font-weight-bold">Teacher training</span> for {{ data.selectedSubject2 }} </h2>
-      <p class="govuk-body">Please provide information and evidence (examples) about the following areas:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>teaching on a PGCE or similar course</li>
-        <li>co-tutoring or where you may have mentored trainee teachers or trainers</li>
-      </ul>
-      <p class="govuk-body govuk-!-margin-bottom-6"><a href="/account/your-details/application">View the evidence you've already provided </a></p>
-
-      {% if data.teachingEvidenceReply == "noReply" %}
+      <p class="govuk-body govuk-!-margin-bottom-6">To proceed with your application we need evidence of your experience in <span class="govuk-!-font-weight-bold">Teacher training for {{ data.selectedSubject2 }}</span>.</p>
+      {% if data.ttrainingEvidenceSent == "" %}
         <div class="govuk-button-group">
           {{ govukButton({
-            text: "Reply to message",
-            href: "/account/messages/reply?referrer=teaching-evidence"
+            text: "Provide evidence",
+            href: "/account/your-details/application/further-evidence-teacher-training"
           }) }}
         </div>
-        {% else %}
+        {% else %} 
       {% endif %}
-
-      {% if data.teachingEvidenceReply == "replied" %}
+      {% if data.ttrainingEvidenceSent == "sent" %}
         <hr>
         <div class="govuk-!-margin-top-6">
-          <p class="govuk-caption-m govuk-!-margin-bottom-0">You replied 1 Mar 2023</p>
-          <h2 class="govuk-heading-l govuk-!-padding-top-0">Your reply</h2>
-          <p class="govuk-body">{{ data.accountMessageReplyTeachingEvidence }}</p>
-          <p class="govuk-body govuk-!-margin-bottom-6"><a href="#">{{ data.accountMessageReplyUploadTeachingEvidence }}</a></p>
-        </div>
-        <div class="govuk-button-group">
-          {{ govukButton({
-            text: "Send another reply",
-            href: "/account/messages/reply?referrer=teaching-evidence"
-          }) }}
+          <p class="govuk-caption-m govuk-!-margin-bottom-0">You sent evidence {{ "" | today |  govukDate }}</p>
+          <h2 class="govuk-heading-l govuk-!-padding-top-0">Your evidence</h2>
+          <p class="govuk-body">{{ data.teachingTeacherTrainingDetailsFurtherEvidence }}</p>
         </div>
         {% else %} 
       {% endif %}
     </div>
   </div>  
-
 {% endblock %}

--- a/app/views/account/messages/further-evidence-required.html
+++ b/app/views/account/messages/further-evidence-required.html
@@ -8,50 +8,25 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <span class="govuk-caption-l">24 Feb 2023 </span>
+      <span class="govuk-caption-l">{{ "" | yesterday |  govukDate }} </span>
       <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
-      <p class="govuk-body">To proceed with your application we need more evidence of your experience in: </p>
-      <h2 class="govuk-heading-m"><span class="govuk-!-font-weight-bold">Making assessment judgements</span> for {{ data.selectedSubject }}</h2>
-      <p class="govuk-body">Please provide information and evidence (examples) about the following areas:</p>
-      <p class="govuk-body govuk-!-margin-bottom-1"><span class="govuk-!-font-weight-bold">Marking assessments</span></p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>marking exam papers or assessment tasks</li>
-        <li>making judgements about candidate's performance against assessment criteria</li>
-      </ul>
-      <p class="govuk-body govuk-!-margin-bottom-1"><span class="govuk-!-font-weight-bold">Standardising the marking of others</span></p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>leading a team of of markers/ examiners/ assessors to ensure marking criteria will be applied accurately and consistently</li>
-      </ul>
-      <p class="govuk-body govuk-!-margin-bottom-1"><span class="govuk-!-font-weight-bold">Moderating the marking of others</span></p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>checking and verifying the marking of others, as a moderator within a school, college, for an awarding organisation or as an internal or external verifier</li>
-      </ul>
-
-      <p class="govuk-body govuk-!-margin-bottom-6"><a href="/account/your-details/application">View the evidence you've already provided </a></p>
-
-      {% if data.subjectEvidenceReply == "noReply" %}
+      <p class="govuk-body">To proceed with your application we more information about your experience in <span class="govuk-!-font-weight-bold">Making assessment judgements for {{ data.selectedSubject }}</span>.</h2>
+      <p class="govuk-body">In your application you mention the type of work you have done but you haven't told us how many years of experience you have. We also need to know the exact qualifications you worked on, including the awarding body. </p>
+      {% if data.makingAssessmentsEvidenceSent == "" %}
         <div class="govuk-button-group">
           {{ govukButton({
-            text: "Reply to message",
-            href: "/account/messages/reply?referrer=subject-evidence"
+            text: "Provide evidence",
+            href: "/account/your-details/application/further-evidence-making-assessment-judgements"
           }) }}
         </div>
         {% else %} 
       {% endif %}
-
-      {% if data.subjectEvidenceReply == "replied" %}
+      {% if data.makingAssessmentsEvidenceSent == "sent" %}
         <hr>
         <div class="govuk-!-margin-top-6">
-          <p class="govuk-caption-m govuk-!-margin-bottom-0">You replied 1 Mar 2023</p>
-          <h2 class="govuk-heading-l govuk-!-padding-top-0">Your reply</h2>
-          <p class="govuk-body">{{ data.accountMessageReplySubjectEvidence }}</p>
-          <p class="govuk-body govuk-!-margin-bottom-6"><a href="#">{{ data.accountMessageReplyUploadSubjectEvidence }}</a></p>
-        </div>
-        <div class="govuk-button-group">
-          {{ govukButton({
-            text: "Send another reply",
-            href: "/account/messages/reply?referrer=subject-evidence"
-          }) }}
+          <p class="govuk-caption-m govuk-!-margin-bottom-0">You sent evidence {{ "" | today |  govukDate }}</p>
+          <h2 class="govuk-heading-l govuk-!-padding-top-0">Your evidence</h2>
+          <p class="govuk-body">{{ data.assessmentJudgementDetailsFurtherEvidence }}</p>
         </div>
         {% else %} 
       {% endif %}

--- a/app/views/account/messages/index.html
+++ b/app/views/account/messages/index.html
@@ -19,6 +19,17 @@
           html: html,
           type: 'success'
         }) }}
+        {% elseif data.referrer == "ttrainingevidencesuccess" or data.referrer == "makingjudgementsevidencesuccess" %}
+          {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+          {% set html %}
+            <h3 class="govuk-notification-banner__heading">
+              Your evidence has been sent.
+            </h3>
+          {% endset %}
+          {{ govukNotificationBanner({
+            html: html,
+            type: 'success'
+          }) }}
         {% else %}
       {% endif %}
     </div>
@@ -126,9 +137,9 @@
                 </td>
                 <!-- sender -->
                 <td class="govuk-table__cell messages--govuk-table__cell">
-                  {% if data.subjectEvidenceReply == "replied" %}
+                  {% if data.makingAssessmentsEvidenceSent == "sent" %}
                     <div class="message read message-subject govuk-body govuk-!-margin-bottom-1">
-                      <p class="govuk-body-s govuk-!-margin-bottom-1">You replied <time datetime="">{{ "" | today |  govukDate }}</time></p>
+                      <p class="govuk-body-s govuk-!-margin-bottom-1">You sent evidence <time datetime="">{{ "" | today |  govukDate }}</time></p>
                     </div>
                     {% else %}
                   {% endif %}
@@ -179,9 +190,9 @@
                 </td>
                 <!-- sender -->
                 <td class="govuk-table__cell messages--govuk-table__cell">
-                  {% if data.teachingEvidenceReply == "replied" %}
+                  {% if data.ttrainingEvidenceSent == "sent" %}
                     <div class="message read message-subject govuk-body govuk-!-margin-bottom-1">
-                      <p class="govuk-body-s govuk-!-margin-bottom-1">You replied <time datetime="">{{ "" | today |  govukDate }}</time></p>
+                      <p class="govuk-body-s govuk-!-margin-bottom-1">You sent evidence <time datetime="">{{ "" | today |  govukDate }}</time></p>
                     </div>
                     {% else %}                
                   {% endif %}

--- a/app/views/account/messages/reply.html
+++ b/app/views/account/messages/reply.html
@@ -11,12 +11,8 @@
   {% set captionHeading %}
     {% if data.referrer == "name-change-proof" %}
       Proof of name change required
-    {% elseif data.referrer == "subject-evidence" %}
-      Further evidence needed for your experience in making assessment judgements
     {% elseif data.referrer == "identity-check-proof"%}
       Verify your identity
-    {% elseif data.referrer == "teaching-evidence"%}
-      Further evidence needed for your experience in teacher training
     {% else %}
     {% endif %}
   {% endset %}
@@ -31,33 +27,8 @@
         <li>unenrolled deed poll or change of name deed</li>
         <li>statutory declaration or affidavit</li>
       </ul>
-    {% elseif data.referrer == "subject-evidence" %}
-      <p class="govuk-body">To proceed with your application we need more evidence of your experience in: </p>
-      <h2 class="govuk-heading-m"><span class="govuk-!-font-weight-bold">Making assessment judgements</span> for Asbestos Analyst and Surveyor (End-Point Assessment - level 3)</h2>
-      <p class="govuk-body">Please provide information and evidence (examples) about the following areas:</p>
-      <p class="govuk-body govuk-!-margin-bottom-1"><span class="govuk-!-font-weight-bold">Marking assessments</span></p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>marking exam papers or assessment tasks</li>
-        <li>making judgements about candidate's performance against assessment criteria</li>
-      </ul>
-      <p class="govuk-body govuk-!-margin-bottom-1"><span class="govuk-!-font-weight-bold">Standardising the marking of others</span></p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>leading a team of of markers/ examiners/ assessors to ensure marking criteria will be applied accurately and consistently</li>
-      </ul>
-      <p class="govuk-body govuk-!-margin-bottom-1"><span class="govuk-!-font-weight-bold">Moderating the marking of others</span></p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>checking and verifying the marking of others, as a moderator within a school, college, for an awarding organisation or as an internal or external verifier</li>
-      </ul>
-    {% elseif data.referrer == "teaching-evidence" %}
-    <p class="govuk-body">To proceed with your application we need more evidence of your experience in: </p>
-    <h2 class="govuk-heading-m"><span class="govuk-!-font-weight-bold">Teacher training</span> for Building control surveyor (integrated degree) (End-point assessment - level 6)</h2>
-    <p class="govuk-body">Please provide information and evidence (examples) about the following areas:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>teaching on a PGCE or similar course</li>
-      <li>co-tutoring or where you may have mentored trainee teachers or trainers</li>
-    </ul>
     {% elseif data.referrer == "identity-check-proof" %}
-    <p class="govuk-body">To proceed with your application we need to verify your identity. To do this please provide one of the following: </p>      
+      <p class="govuk-body">To proceed with your application we need to verify your identity. To do this please provide one of the following: </p>      
       <p class="govuk-body govuk-!-margin-bottom-1"><span class="govuk-!-font-weight-bold">A UK or Irish passport</span></p>
       <ul class="govuk-list govuk-list--bullet">
         <li>An official letter or document from a government agency or previous employer, showing your name and National Insurance number</li>
@@ -100,31 +71,6 @@
 
     {# This sets the reply status on the message list #}
     <input type="hidden" name="proofNameChangeReply" value="replied">
-
-  {% elseif data.referrer == "subject-evidence" %}
-      {{ govukDetails({
-        summaryText: "View the message you are replying to",
-        html: detailsHtml
-      }) }}
-
-      {{ govukCharacterCount({
-        maxwords: 500,
-        rows: "10",
-        label: {
-          text: "Your message",
-          classes: "govuk-label--m"
-        }
-      } | decorateAttributes(data, "data.accountMessageReplySubjectEvidence")) }}
-
-    {{ govukFileUpload({
-      label: {
-        text: "Upload a file",
-        classes: "govuk-label--m"
-      }
-    } | decorateAttributes(data, "data.accountMessageReplyUploadSubjectEvidence")) }}
-    
-    {# This sets the reply status on the message list #}
-    <input type="hidden" name="subjectEvidenceReply" value="replied">
     
     {% elseif data.referrer == "identity-check-proof" %}
       {{ govukDetails({
@@ -150,31 +96,6 @@
     
     {# This sets the reply status on the message list #}
     <input type="hidden" name="identityCheckReply" value="replied">
-
-  {% elseif data.referrer == "teaching-evidence" %}
-    {{ govukDetails({
-      summaryText: "View the message you are replying to",
-      html: detailsHtml
-    }) }}
-
-    {{ govukCharacterCount({
-      maxwords: 500,
-      rows: "10",
-      label: {
-        text: "Your message",
-        classes: "govuk-label--m"
-      }
-    } | decorateAttributes(data, "data.accountMessageReplyTeachingEvidence")) }}
-
-    {{ govukFileUpload({
-      label: {
-        text: "Upload a file",
-        classes: "govuk-label--m"
-      }
-    } | decorateAttributes(data, "data.accountMessageReplyUploadTeachingEvidence")) }}
-  
-    {# This sets the reply status on the message list #}
-    <input type="hidden" name="teachingEvidenceReply" value="replied">
   {% else %}
   {% endif %}
   <div class="govuk-button-group">

--- a/app/views/account/your-details/application/further-evidence-making-assessment-judgements/index.html
+++ b/app/views/account/your-details/application/further-evidence-making-assessment-judgements/index.html
@@ -1,0 +1,70 @@
+
+{% extends "_templates/form-template.html" %}
+
+{% set primaryNavActive = "Your details" %}
+{% set pageType = "Account" %}
+{% set pageTypeSub = "Your details" %}
+{% set formAction = "/account/your-details/application/further-evidence-making-assessment-judgements/review" %}
+
+{% set pageHeading = "Provide further evidence of your experience in making assessment judgements" %}
+
+{% block formContent %}
+
+  <span class="govuk-caption-l">Further evidence </span>
+  <h1 class="govuk-heading-l">Making assessment judgements</h1>
+
+  {% set detailsHtml %}
+    <p class="govuk-body">This is your opportunity to provide information and evidence about the following areas:</p>
+    <p class="govuk-body govuk-!-margin-bottom-1"><span class="govuk-!-font-weight-bold">Marking assessments</span></p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>marking exam papers or assessment tasks</li>
+      <li>making judgements about candidate's performance against assessment criteria</li>
+    </ul>
+    <p class="govuk-body govuk-!-margin-bottom-1"><span class="govuk-!-font-weight-bold">Standardising the marking of others</span></p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>leading a team of of markers/ examiners/ assessors to ensure marking criteria will be applied accurately and consistently</li>
+    </ul>
+    <p class="govuk-body govuk-!-margin-bottom-1"><span class="govuk-!-font-weight-bold">Moderating the marking of others</span></p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>checking and verifying the marking of others, as a moderator within a school, college, for an awarding organisation or as an internal or external verifier</li>
+    </ul>
+  {% endset %}
+
+  {% set previousAnswerHtml %}
+    <p class="govuk-body">{{ data.assessmentJudgementDetails }}</p>
+  {% endset %}
+  
+  <p class="govuk-body">To proceed with your application we need more information about your experience in making assessment judgements for <strong>{{ data.selectedSubject }}</strong>.</p>
+  <p class="govuk-body">In your application you mention the type of work you have done but you haven't told us how many years of experience you have. We also need to know the exact qualifications you worked, including the awarding body. </p>
+
+  {{ govukDetails({
+    summaryText: "Evidence you've already provided",
+    html: previousAnswerHtml,
+    classes: "govuk-!-margin-bottom-2"
+  }) }}
+
+  {{ govukDetails({
+    summaryText: "What should I include?",
+    html: detailsHtml
+  }) }}
+
+  {{ govukCharacterCount({
+    maxwords: 500,
+    rows: "14",
+    label: {
+      text: pageHeading,
+      classes: "govuk-label--m"
+    }
+   } | decorateAttributes(data, "data.assessmentJudgementDetailsFurtherEvidence")) }}
+
+  <div class="govuk-button-group">
+    {{ govukButton({
+      text: "Save and continue"
+    }) }}
+    <a class="govuk-link" href="/account/messages/further-evidence-required">Cancel</a>
+  </div>
+
+{% endblock %}
+
+
+

--- a/app/views/account/your-details/application/further-evidence-making-assessment-judgements/review.html
+++ b/app/views/account/your-details/application/further-evidence-making-assessment-judgements/review.html
@@ -1,0 +1,28 @@
+
+{% extends "_templates/form-template.html" %}
+
+{% set primaryNavActive = "Your details" %}
+{% set pageType = "Account" %}
+{% set pageTypeSub = "FurtherEvidence" %}
+
+{% set pageHeading = "Review your further evidence for making assessment judgements" %}
+{% set formAction = "/account/messages?referrer=makingjudgementsevidencesuccess" %}
+{% set layoutWidth = "fullWidthLayout" %}
+
+{% block formContent %}
+
+  <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+  
+  {% include "_includes/summary-cards/further-evidence-making-assessment-judgements.html" %}
+
+  <div class="govuk-button-group">
+    {{ govukButton({
+      text: "Send evidence"
+    }) }}
+    <a class="govuk-link" href="/account/messages/further-evidence-required">Cancel</a>
+  </div>
+
+  {# This sets the reply status on the message list and status box #}
+  <input type="hidden" name="makingAssessmentsEvidenceSent" value="sent">
+
+{% endblock %}

--- a/app/views/account/your-details/application/further-evidence-teacher-training/index.html
+++ b/app/views/account/your-details/application/further-evidence-teacher-training/index.html
@@ -1,0 +1,55 @@
+
+{% extends "_templates/form-template.html" %}
+
+{% set primaryNavActive = "Your details" %}
+{% set pageType = "Account" %}
+{% set pageTypeSub = "Your details" %}
+{% set formAction = "/account/your-details/application/further-evidence-teacher-training/review" %}
+
+{% set pageHeading = "Provide further evidence of your experience in teacher training" %}
+
+{% block formContent %}
+  <span class="govuk-caption-l">Further evidence </span>
+  <h1 class="govuk-heading-l">Teacher training</h1>
+
+  {% set detailsHtml %}
+    <p class="govuk-body">This is your opportunity to provide information and evidence about the following areas:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>teaching on a PGCE or similar course</li>
+      <li>co-tutoring or where you may have mentored trainee teachers or trainers</li>
+    </ul>
+  {% endset %}
+
+  {% set previousAnswerHtml %}
+    <p class="govuk-body">{{ data.teachingTeacherTrainingDetails }}</p>
+  {% endset %}
+  
+  <p class="govuk-body">To proceed with your application we need evidence of your experience in <span class="govuk-!-font-weight-bold">Teacher training for {{ data.selectedSubject2 }}</span>.</p>  
+  {{ govukDetails({
+    summaryText: "Evidence you've already provided",
+    html: previousAnswerHtml,
+    classes: "govuk-!-margin-bottom-2"
+  }) }}
+
+  {{ govukDetails({
+    summaryText: "What should I include?",
+    html: detailsHtml
+  }) }}
+
+  {{ govukCharacterCount({
+    maxwords: 500,
+    rows: "14",
+    label: {
+      text: pageHeading,
+      classes: "govuk-label--m"
+    }
+   } | decorateAttributes(data, "data.teachingTeacherTrainingDetailsFurtherEvidence")) }}
+
+  <div class="govuk-button-group">
+    {{ govukButton({
+      text: "Save and continue"
+    }) }}
+    <a class="govuk-link" href="/account/messages/further-evidence-required-ttraining">Cancel</a>
+  </div>
+
+{% endblock %}

--- a/app/views/account/your-details/application/further-evidence-teacher-training/review.html
+++ b/app/views/account/your-details/application/further-evidence-teacher-training/review.html
@@ -1,0 +1,28 @@
+
+{% extends "_templates/form-template.html" %}
+
+{% set primaryNavActive = "Your details" %}
+{% set pageType = "Account" %}
+{% set pageTypeSub = "FurtherEvidence" %}
+
+{% set pageHeading = "Review your further evidence for teacher training" %}
+{% set formAction = "/account/messages?referrer=ttrainingevidencesuccess" %}
+{% set layoutWidth = "fullWidthLayout" %}
+
+{% block formContent %}
+
+  <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+  
+  {% include "_includes/summary-cards/further-evidence-teacher-training.html" %}
+
+  <div class="govuk-button-group">
+    {{ govukButton({
+      text: "Send evidence"
+    }) }}
+    <a class="govuk-link" href="/account/messages/further-evidence-required-ttraining">Cancel</a>
+  </div>
+
+  {# This sets the reply status on the message list and status box #}
+  <input type="hidden" name="ttrainingEvidenceSent" value="sent">
+
+{% endblock %}


### PR DESCRIPTION
- changing how a user supplied further evidence for subjects
- now works as a form rather than a message 
- text after sending updated to 'sent' instead of 'reply'
- after sending evidence it then shows under the 'further supporting evidence' section on the application page
- updated the examples for further evidence, to have 1 that is generic (e.g for teacher training the person hasn't written about that subject so evidence is being requested) and 1 that is specific and has a custom block of text in the message and form page which would be written by an Ofqual admin (e.g. the making assessment judgements needs specific information adding to their answer). 
- success banner for these as 'evidence sent' instead of 'message sent'
- removed code for reply for these messages. 